### PR TITLE
refactor: shrink public API surface (~21 names removed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,20 +314,7 @@ let agent = Agent::builder(client, "deepseek-chat")
     .build()?;
 ```
 
-### Dynamic planning — `prepare_call` / `prepare_step`
-
-`prepare_call` runs once before the agent loop starts and mutates the run plan in place:
-
-```rust
-let agent = Agent::builder(client, "deepseek-chat")
-    .prepare_call(|plan| {
-        if plan.messages.len() > 6 {
-            plan.temperature = Some(0.0);
-            plan.max_output_tokens = Some(400);
-        }
-    })
-    .build()?;
-```
+### Dynamic planning — `prepare_step`
 
 `prepare_step` runs before every step and returns a fresh prepared plan — useful for shrinking the tool set, switching models, or injecting per-step instructions:
 
@@ -392,29 +379,40 @@ See `examples/mini_claude_code.rs` for a working terminal agent that uses this p
 ## Multimodal vision
 
 ```rust
-use aquaregia::{GenerateTextRequest, LlmClient, Message};
+use aquaregia::{
+    ContentPart, GenerateTextRequest, ImagePart, LlmClient, MediaData, Message, MessageRole,
+};
 
 let client = LlmClient::anthropic(std::env::var("ANTHROPIC_API_KEY")?).build()?;
 
 let out = client
     .generate(
         GenerateTextRequest::builder("claude-sonnet-4-5")
-            .message(Message::user_text_and_image_url(
-                "What's in this image?",
-                "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg",
-            ))
+            .message(Message::new(
+                MessageRole::User,
+                vec![
+                    ContentPart::Text("What's in this image?".into()),
+                    ContentPart::Image(ImagePart {
+                        data: MediaData::Url(
+                            "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg".into(),
+                        ),
+                        media_type: None,
+                        provider_metadata: None,
+                    }),
+                ],
+            )?)
             .build()?,
     )
     .await?;
 ```
 
-Three convenience constructors plus a full-control form:
+Two convenience constructors plus a full-control form:
 
 | Constructor                                                              | Use case                                  |
 | ------------------------------------------------------------------------ | ----------------------------------------- |
 | `Message::user_image_url(url)`                                           | Single image from a URL                   |
 | `Message::user_image_bytes(bytes, mime)`                                 | Single image from raw bytes (auto base64) |
-| `Message::user_text_and_image_url(text, url)`                            | Text + image in one user message          |
+| `Message::new(MessageRole::User, vec![Text, Image, …])`                  | Mixed content (text + image, multi-image) |
 | `ContentPart::Image(ImagePart { data, media_type, provider_metadata })`  | Full control + provider-specific hints    |
 
 Each provider sees its own native format:
@@ -453,11 +451,15 @@ match client.generate(req).await {
 }
 ```
 
-Agents have dedicated helpers:
+Agents bind the token at builder time:
 
 ```rust
-agent.run_cancellable("hello", token.clone()).await?;
-agent.run_messages_cancellable(messages, token).await?;
+let agent = Agent::builder(client, "deepseek-chat")
+    .cancellation_token(token.clone())
+    .build()?;
+
+agent.run("hello").await?;
+agent.run_messages(messages).await?;
 ```
 
 Cancellation is checked **before every HTTP send** (via `tokio::select!`, zero overhead on the happy path), **after every SSE chunk** in streaming responses, and **at the top of every agent step** in the tool loop.
@@ -581,10 +583,10 @@ DEEPSEEK_API_KEY=... cargo run --example basic_generate
 | `basic_stream`                | `stream` + `StreamEvent` handling                           |
 | `agent_minimal`               | `Agent::builder` with one typed tool                        |
 | `tools_max_steps`             | Multi-tool loop with `max_steps` and sampling caps          |
-| `prepare_hooks`               | `prepare_call`, `prepare_step`, `on_step_finish`            |
+| `prepare_hooks`               | `prepare_step`, `on_step_finish`                            |
 | `openai_compatible_custom`    | Custom headers / query params / chat path                   |
 | `mini_claude_code`            | TUI code agent — `bash` / `read` / `write` / `edit` tools   |
-| `multimodal_image`            | `Message::user_text_and_image_url` + Anthropic vision       |
+| `multimodal_image`            | `Message::new` with mixed text + image parts + Anthropic vision |
 
 Set `DEEPSEEK_API_KEY` for most examples; `ANTHROPIC_API_KEY` for `multimodal_image`. See [`examples/README.md`](./examples/README.md) for full descriptions.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -313,20 +313,7 @@ let agent = Agent::builder(client, "deepseek-chat")
     .build()?;
 ```
 
-### 动态规划 —— `prepare_call` / `prepare_step`
-
-`prepare_call` 在整个 Agent 循环开始前运行一次，直接修改运行计划：
-
-```rust
-let agent = Agent::builder(client, "deepseek-chat")
-    .prepare_call(|plan| {
-        if plan.messages.len() > 6 {
-            plan.temperature = Some(0.0);
-            plan.max_output_tokens = Some(400);
-        }
-    })
-    .build()?;
-```
+### 动态规划 —— `prepare_step`
 
 `prepare_step` 在每一步前运行，返回一份新的 prepared plan —— 适合裁剪工具集、切换模型、注入分步指令：
 
@@ -391,29 +378,40 @@ loop {
 ## 多模态视觉
 
 ```rust
-use aquaregia::{GenerateTextRequest, LlmClient, Message};
+use aquaregia::{
+    ContentPart, GenerateTextRequest, ImagePart, LlmClient, MediaData, Message, MessageRole,
+};
 
 let client = LlmClient::anthropic(std::env::var("ANTHROPIC_API_KEY")?).build()?;
 
 let out = client
     .generate(
         GenerateTextRequest::builder("claude-sonnet-4-5")
-            .message(Message::user_text_and_image_url(
-                "这张图里有什么？",
-                "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg",
-            ))
+            .message(Message::new(
+                MessageRole::User,
+                vec![
+                    ContentPart::Text("这张图里有什么？".into()),
+                    ContentPart::Image(ImagePart {
+                        data: MediaData::Url(
+                            "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg".into(),
+                        ),
+                        media_type: None,
+                        provider_metadata: None,
+                    }),
+                ],
+            )?)
             .build()?,
     )
     .await?;
 ```
 
-三个便捷构造器 + 一个完全自定义形式：
+两个便捷构造器 + 一个完全自定义形式：
 
 | 构造器                                                                  | 场景                                  |
 | ----------------------------------------------------------------------- | ------------------------------------- |
 | `Message::user_image_url(url)`                                          | 单张图像，来自 URL                    |
 | `Message::user_image_bytes(bytes, mime)`                                | 单张图像，来自原始字节（自动 base64） |
-| `Message::user_text_and_image_url(text, url)`                           | 文字 + 图像 URL 合为一条用户消息      |
+| `Message::new(MessageRole::User, vec![Text, Image, …])`                 | 混合内容（文字 + 图像、多图）          |
 | `ContentPart::Image(ImagePart { data, media_type, provider_metadata })` | 完全自定义，可附带 provider 专用提示  |
 
 各 provider 接收各自的原生格式：
@@ -452,11 +450,15 @@ match client.generate(req).await {
 }
 ```
 
-Agent 提供专用的可取消方法：
+Agent 在 builder 上绑定取消令牌：
 
 ```rust
-agent.run_cancellable("你好", token.clone()).await?;
-agent.run_messages_cancellable(messages, token).await?;
+let agent = Agent::builder(client, "deepseek-chat")
+    .cancellation_token(token.clone())
+    .build()?;
+
+agent.run("你好").await?;
+agent.run_messages(messages).await?;
 ```
 
 取消检查点：**每次 HTTP 发送前**（通过 `tokio::select!`，未取消时零开销）、**每个 SSE chunk 之后**、**工具循环中每个 Agent 步骤开始时**。
@@ -580,10 +582,10 @@ DEEPSEEK_API_KEY=... cargo run --example basic_generate
 | `basic_stream`                | `stream` + `StreamEvent` 处理                                 |
 | `agent_minimal`               | `Agent::builder` + 单个类型化工具                             |
 | `tools_max_steps`             | 多工具循环 + `max_steps` + 采样参数                           |
-| `prepare_hooks`               | `prepare_call`、`prepare_step`、`on_step_finish`              |
+| `prepare_hooks`               | `prepare_step`、`on_step_finish`                             |
 | `openai_compatible_custom`    | 自定义 headers / query params / chat path                     |
 | `mini_claude_code`            | TUI Code Agent —— `bash` / `read` / `write` / `edit` 工具     |
-| `multimodal_image`            | `Message::user_text_and_image_url` + Anthropic 视觉           |
+| `multimodal_image`            | `Message::new` 组合文字 + 图像 part + Anthropic 视觉           |
 
 大多数示例需要 `DEEPSEEK_API_KEY`；`multimodal_image` 需要 `ANTHROPIC_API_KEY`。完整说明见 [`examples/README.md`](./examples/README.md)。
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -50,13 +50,13 @@
 
 8. `prepare_hooks.rs`
 
-- 场景：动态控制每次调用和每一步执行（对齐 AI SDK 的 `prepareCall/prepareStep`）。
-- 重点：`prepare_call`、`prepare_step`、在 step 前动态改消息/工具/采样参数。
+- 场景：动态控制每一步执行（对齐 AI SDK 的 `prepareStep`）。
+- 重点：`prepare_step`、在 step 前动态改消息/工具/采样参数。
 
 9. `multimodal_image.rs`
 
 - 场景：向视觉模型发送图像（URL / base64 / 原始字节）。
-- 重点：`Message::user_text_and_image_url`、`Message::user_image_bytes`、`ImagePart`、`MediaData`。
+- 重点：`Message::new` 组合文字 + 图像 part、`Message::user_image_bytes`、`ImagePart`、`MediaData`。
 - 运行：`ANTHROPIC_API_KEY=<key> cargo run --example multimodal_image`
 
 ## 建议阅读顺序

--- a/examples/multimodal_image.rs
+++ b/examples/multimodal_image.rs
@@ -3,19 +3,33 @@
 //! Run with:
 //!   ANTHROPIC_API_KEY=<key> cargo run --example multimodal_image
 
-use aquaregia::{GenerateTextRequest, ImagePart, LlmClient, MediaData, Message};
+use aquaregia::{
+    ContentPart, GenerateTextRequest, ImagePart, LlmClient, MediaData, Message, MessageRole,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = LlmClient::anthropic(std::env::var("ANTHROPIC_API_KEY")?).build()?;
 
+    let message = Message::new(
+        MessageRole::User,
+        vec![
+            ContentPart::Text("What's in this image?".into()),
+            ContentPart::Image(ImagePart {
+                data: MediaData::Url(
+                    "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg"
+                        .into(),
+                ),
+                media_type: None,
+                provider_metadata: None,
+            }),
+        ],
+    )?;
+
     let response = client
         .generate(
             GenerateTextRequest::builder("claude-sonnet-4-5")
-                .message(Message::user_text_and_image_url(
-                    "What's in this image?",
-                    "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg",
-                ))
+                .message(message)
                 .build()?,
         )
         .await?;
@@ -31,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Example: explicit ImagePart with base64
-    let _explicit_example = aquaregia::ContentPart::Image(ImagePart {
+    let _explicit_example = ContentPart::Image(ImagePart {
         data: MediaData::Base64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==".to_string()),
         media_type: Some("image/png".to_string()),
         provider_metadata: None,

--- a/examples/prepare_hooks.rs
+++ b/examples/prepare_hooks.rs
@@ -33,16 +33,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .instructions("You may call tools, then answer concisely.")
         .tools([time_tool])
         .max_steps(4)
-        // 对应 AI SDK prepareCall：在一次调用开始前可动态改调用计划。
-        .prepare_call(|plan| {
-            if user_mentions_keyword(&plan.messages, "json") {
-                plan.temperature = Some(0.0);
-                plan.max_output_tokens = Some(400);
-            }
-        })
-        // 对应 AI SDK prepareStep：每一步前可动态改模型/消息/工具等。
+        // 对应 AI SDK prepareStep：每一步前可动态改模型/消息/工具/采样。
         .prepare_step(|event| {
             let mut next = event.to_prepared();
+
+            // 首步：根据用户输入关键词动态调整采样参数。
+            if event.step == 1 && user_mentions_keyword(&next.messages, "json") {
+                next.temperature = Some(0.0);
+                next.max_output_tokens = Some(400);
+            }
 
             next.messages.push(Message::system_text(format!(
                 "Current step: {}. Use minimal tools.",

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -4,7 +4,6 @@
 //!
 //! - [`Agent<P>`]: Main agent runtime for tool loops
 //! - [`AgentBuilder<P>`]: Builder for configuring agent behavior
-//! - [`AgentRunPlan<P>`]: Mutable plan for customizing agent runs
 //!
 //! ## Agent Architecture
 //!
@@ -54,51 +53,6 @@ use crate::types::{
     validate_model_ref, validate_sampling,
 };
 
-/// Callback type for mutating agent run plans before execution.
-pub(crate) type PrepareCallHook<P> = Arc<dyn Fn(&mut AgentRunPlan<P>) + Send + Sync>;
-
-/// Mutable plan for one agent run before execution starts.
-///
-/// This struct is passed to `prepare_call` callbacks so callers can adjust
-/// request-level settings (model, messages, tools, sampling, limits) per invocation.
-/// This enables dynamic model selection, tool filtering, and parameter tuning.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use aquaregia::{Agent, LlmClient};
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = LlmClient::openai("key").build()?;
-///
-/// let agent = Agent::builder(client, "gpt-4o")
-///     .prepare_call(|plan| {
-///         // Dynamically adjust temperature based on task
-///         plan.temperature = Some(0.7);
-///     })
-///     .build()?;
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug, Clone)]
-pub struct AgentRunPlan<P: ProviderMarker> {
-    /// Model selected for this run.
-    pub model: ModelRef<P>,
-    /// Initial message list to start the loop with.
-    pub messages: Vec<Message>,
-    /// Tools available to the model.
-    pub tools: Vec<Tool>,
-    /// Step cap for this run. `None` falls back to client default.
-    pub max_steps: Option<u8>,
-    /// Sampling temperature in range `0.0..=2.0`.
-    pub temperature: Option<f32>,
-    /// Nucleus sampling value in range `0.0..=1.0`.
-    pub top_p: Option<f32>,
-    /// Maximum output token budget per model call.
-    pub max_output_tokens: Option<u32>,
-    /// Stop sequences forwarded to provider requests.
-    pub stop_sequences: Vec<String>,
-}
-
 /// Multi-step tool-using agent bound to one provider and one default model.
 ///
 /// The agent implements a tool-use loop that:
@@ -110,52 +64,33 @@ pub struct AgentRunPlan<P: ProviderMarker> {
 /// ## Features
 ///
 /// - **Configurable hooks**: Callbacks for run start, step start/finish, tool call start/finish
-/// - **Dynamic planning**: `prepare_call` and `prepare_step` callbacks for runtime adjustments
+/// - **Dynamic planning**: `prepare_step` callback for runtime per-step adjustments
 /// - **Early stopping**: `stop_when` predicate for custom termination conditions
-/// - **Cancellation**: Support for `CancellationToken` to cancel running agents
+/// - **Cancellation**: Bind a `CancellationToken` at builder time to cancel running agents
 /// - **Error policies**: Configurable tool error handling (`ContinueAsToolResult` or `FailFast`)
 ///
 /// ## Type Parameters
 ///
 /// * `P` - Provider marker type encoding the bound provider at compile time
 pub struct Agent<P: ProviderMarker> {
-    /// Bound client for making LLM requests.
     client: Arc<BoundClient<P>>,
-    /// Default model for this agent.
     model: ModelRef<P>,
-    /// System instructions prepended to runs.
     instructions: Option<String>,
-    /// Registered tools available to the agent.
     tools: Vec<Tool>,
-    /// Maximum number of tool-use loop iterations.
     max_steps: Option<u8>,
-    /// Default sampling temperature.
     temperature: Option<f32>,
-    /// Default nucleus sampling value.
     top_p: Option<f32>,
-    /// Default maximum output token budget.
     max_output_tokens: Option<u32>,
-    /// Default stop sequences.
     stop_sequences: Vec<String>,
-    /// Callback to mutate run plans before execution.
-    prepare_call: Option<PrepareCallHook<P>>,
-    /// Callback to mutate step inputs before each model call.
+    cancellation_token: Option<CancellationToken>,
     prepare_step: Option<PrepareStepHook<P>>,
-    /// Callback fired once before the first step.
     on_start: Option<Hook<AgentStart>>,
-    /// Callback fired at the beginning of each step.
     on_step_start: Option<Hook<AgentStepStart>>,
-    /// Callback fired right before each tool execution.
     on_tool_call_start: Option<Hook<AgentToolCallStart>>,
-    /// Callback fired right after each tool execution.
     on_tool_call_finish: Option<Hook<AgentToolCallFinish>>,
-    /// Callback fired after each completed step.
     on_step_finish: Option<Hook<AgentStep>>,
-    /// Callback fired once when the run finishes successfully.
     on_finish: Option<Hook<AgentFinish>>,
-    /// Early-stop predicate evaluated after each step.
     stop_when: Option<StopPredicate>,
-    /// Policy for handling tool execution errors.
     tool_error_policy: ToolErrorPolicy,
 }
 
@@ -194,7 +129,7 @@ impl<P: ProviderMarker> Agent<P> {
         prompt: impl Into<String>,
     ) -> Result<AgentResponse, crate::error::Error> {
         let messages = vec![Message::user_text(prompt)];
-        self.run_messages_inner(self.inject_instructions(messages), None)
+        self.run_messages_inner(self.inject_instructions(messages))
             .await
     }
 
@@ -207,73 +142,33 @@ impl<P: ProviderMarker> Agent<P> {
         &self,
         messages: Vec<Message>,
     ) -> Result<AgentResponse, crate::error::Error> {
-        self.run_messages_inner(self.inject_instructions(messages), None)
-            .await
-    }
-
-    /// Runs the agent with a prompt and cancellation support.
-    pub async fn run_cancellable(
-        &self,
-        prompt: impl Into<String>,
-        token: CancellationToken,
-    ) -> Result<AgentResponse, crate::error::Error> {
-        let messages = vec![Message::user_text(prompt)];
-        self.run_messages_cancellable(self.inject_instructions(messages), token)
-            .await
-    }
-
-    /// Runs the agent with explicit messages and cancellation support.
-    ///
-    /// If `instructions` were configured and the message list does not already
-    /// contain a system message, the instructions are inserted as a system
-    /// message at the front of the list.
-    pub async fn run_messages_cancellable(
-        &self,
-        messages: Vec<Message>,
-        token: CancellationToken,
-    ) -> Result<AgentResponse, crate::error::Error> {
-        self.run_messages_inner(self.inject_instructions(messages), Some(token))
+        self.run_messages_inner(self.inject_instructions(messages))
             .await
     }
 
     async fn run_messages_inner(
         &self,
         messages: Vec<Message>,
-        token: Option<CancellationToken>,
     ) -> Result<AgentResponse, crate::error::Error> {
-        let mut call_plan = AgentRunPlan {
-            model: self.model.clone(),
-            messages,
-            tools: self.tools.clone(),
-            max_steps: self.max_steps,
-            temperature: self.temperature,
-            top_p: self.top_p,
-            max_output_tokens: self.max_output_tokens,
-            stop_sequences: self.stop_sequences.clone(),
-        };
-        if let Some(callback) = &self.prepare_call {
-            callback(&mut call_plan);
-        }
-
-        let mut request = RunTools::new(call_plan.model)
-            .messages(call_plan.messages)
-            .tools(call_plan.tools)
+        let mut request = RunTools::new(self.model.clone())
+            .messages(messages)
+            .tools(self.tools.clone())
             .tool_error_policy(self.tool_error_policy)
-            .stop_sequences(call_plan.stop_sequences);
+            .stop_sequences(self.stop_sequences.clone());
 
-        if let Some(t) = token {
-            request = request.cancellation_token(t);
+        if let Some(t) = &self.cancellation_token {
+            request = request.cancellation_token(t.clone());
         }
-        if let Some(max_steps) = call_plan.max_steps {
+        if let Some(max_steps) = self.max_steps {
             request = request.max_steps(max_steps);
         }
-        if let Some(temperature) = call_plan.temperature {
+        if let Some(temperature) = self.temperature {
             request = request.temperature(temperature);
         }
-        if let Some(top_p) = call_plan.top_p {
+        if let Some(top_p) = self.top_p {
             request = request.top_p(top_p);
         }
-        if let Some(max_output_tokens) = call_plan.max_output_tokens {
+        if let Some(max_output_tokens) = self.max_output_tokens {
             request = request.max_output_tokens(max_output_tokens);
         }
 
@@ -327,7 +222,7 @@ pub struct AgentBuilder<P: ProviderMarker> {
     top_p: Option<f32>,
     max_output_tokens: Option<u32>,
     stop_sequences: Vec<String>,
-    prepare_call: Option<PrepareCallHook<P>>,
+    cancellation_token: Option<CancellationToken>,
     prepare_step: Option<PrepareStepHook<P>>,
     on_start: Option<Hook<AgentStart>>,
     on_step_start: Option<Hook<AgentStepStart>>,
@@ -351,7 +246,7 @@ impl<P: ProviderMarker> AgentBuilder<P> {
             top_p: None,
             max_output_tokens: None,
             stop_sequences: Vec::new(),
-            prepare_call: None,
+            cancellation_token: None,
             prepare_step: None,
             on_start: None,
             on_step_start: None,
@@ -415,12 +310,13 @@ impl<P: ProviderMarker> AgentBuilder<P> {
         self
     }
 
-    /// Registers a callback to mutate [`AgentRunPlan`] before execution starts.
-    pub fn prepare_call<F>(mut self, callback: F) -> Self
-    where
-        F: Fn(&mut AgentRunPlan<P>) + Send + Sync + 'static,
-    {
-        self.prepare_call = Some(Arc::new(callback));
+    /// Binds a [`CancellationToken`] checked during agent execution.
+    ///
+    /// When the token is cancelled, the agent stops before the next step and returns
+    /// [`crate::ErrorCode::Cancelled`]. To cancel different runs independently, build
+    /// a separate agent per token.
+    pub fn cancellation_token(mut self, token: CancellationToken) -> Self {
+        self.cancellation_token = Some(token);
         self
     }
 
@@ -520,7 +416,7 @@ impl<P: ProviderMarker> AgentBuilder<P> {
             top_p: self.top_p,
             max_output_tokens: self.max_output_tokens,
             stop_sequences: self.stop_sequences,
-            prepare_call: self.prepare_call,
+            cancellation_token: self.cancellation_token,
             prepare_step: self.prepare_step,
             on_start: self.on_start,
             on_step_start: self.on_step_start,
@@ -537,7 +433,7 @@ impl<P: ProviderMarker> AgentBuilder<P> {
 #[cfg(test)]
 mod tests {
     use super::Agent;
-    use crate::{LlmClient, openai};
+    use crate::LlmClient;
 
     #[test]
     fn builder_accepts_typed_model() {
@@ -545,7 +441,7 @@ mod tests {
             .base_url("https://api.openai.com")
             .build()
             .expect("client should build");
-        let agent = Agent::builder(client, openai("gpt-4o-mini"))
+        let agent = Agent::builder(client, "gpt-4o-mini")
             .max_steps(3)
             .build()
             .expect("agent should build");
@@ -559,7 +455,7 @@ mod tests {
             .base_url("https://api.openai.com")
             .build()
             .expect("client should build");
-        let err = match Agent::builder(client, openai("gpt-4o-mini"))
+        let err = match Agent::builder(client, "gpt-4o-mini")
             .top_p(1.5)
             .build()
         {

--- a/src/error.rs
+++ b/src/error.rs
@@ -206,7 +206,7 @@ impl Error {
     ///
     /// This method adds the request ID from provider response headers,
     /// useful for tracing and support inquiries with the provider.
-    pub fn with_request_id(mut self, request_id: Option<String>) -> Self {
+    pub(crate) fn with_request_id(mut self, request_id: Option<String>) -> Self {
         self.request_id = request_id;
         self
     }
@@ -215,7 +215,7 @@ impl Error {
     ///
     /// This method preserves the original provider error response body
     /// for debugging and diagnostics.
-    pub fn with_raw_body(mut self, raw_body: Option<String>) -> Self {
+    pub(crate) fn with_raw_body(mut self, raw_body: Option<String>) -> Self {
         self.raw_body = raw_body;
         self
     }
@@ -237,7 +237,7 @@ impl Error {
 /// - `500-599` → [`ErrorCode::ProviderServerError`]
 /// - `400-499` → [`ErrorCode::InvalidRequest`]
 /// - Others → [`ErrorCode::Transport`]
-pub fn classify_http_error(status: u16) -> ErrorCode {
+pub(crate) fn classify_http_error(status: u16) -> ErrorCode {
     match status {
         401 | 403 => ErrorCode::AuthFailed,
         429 => ErrorCode::RateLimited,
@@ -256,7 +256,7 @@ pub fn classify_http_error(status: u16) -> ErrorCode {
 /// # Arguments
 ///
 /// * `code` - Error code to check
-pub fn is_retryable(code: ErrorCode) -> bool {
+pub(crate) fn is_retryable(code: ErrorCode) -> bool {
     matches!(
         code,
         ErrorCode::RateLimited

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,7 @@ pub mod client;
 pub mod error;
 /// Provider adapter traits and concrete provider implementations.
 pub mod model_adapters;
-/// SSE frame parsing helpers used by streaming adapters.
-pub mod stream;
+pub(crate) mod stream;
 /// Tool definition, execution, and registry types.
 pub mod tool;
 /// Shared request/response and event types.
@@ -73,7 +72,7 @@ pub use model_adapters::openai_compatible::OpenAiCompatibleAdapterSettings;
 pub use tokio_util::sync::CancellationToken;
 
 pub use tool::{
-    IntoTool, Tool, ToolBuilder, ToolDescriptor, ToolExecError, ToolExecutor, ToolRegistry, tool,
+    IntoTool, Tool, ToolBuilder, ToolDescriptor, ToolExecError, ToolExecutor, tool,
 };
 pub use types::{
     AgentFinish,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub mod tool;
 /// Shared request/response and event types.
 pub mod types;
 
-pub use agent::{Agent, AgentBuilder, AgentRunPlan};
+pub use agent::{Agent, AgentBuilder};
 pub use client::{BoundClient, ClientBuilder, LlmClient};
 pub use error::{Error, ErrorCode};
 pub use model_adapters::ModelAdapter;
@@ -115,87 +115,3 @@ pub use types::{
     ToolResult,
     Usage,
 };
-
-/// Creates a typed OpenAI model reference (`openai/<model>`).
-///
-/// This function provides a convenient way to create a [`ModelRef`] for OpenAI models
-/// with compile-time provider type safety.
-///
-/// # Arguments
-///
-/// * `model` - The OpenAI model identifier (e.g., `"gpt-4o"`, `"gpt-4o-mini"`)
-///
-/// # Example
-///
-/// ```
-/// use aquaregia::openai;
-///
-/// let model = openai("gpt-4o");
-/// assert_eq!(model.id(), "openai/gpt-4o");
-/// ```
-pub fn openai(model: impl Into<String>) -> ModelRef<OpenAi> {
-    ModelRef::<OpenAi>::new(model)
-}
-
-/// Creates a typed Anthropic model reference (`anthropic/<model>`).
-///
-/// This function provides a convenient way to create a [`ModelRef`] for Anthropic models
-/// with compile-time provider type safety.
-///
-/// # Arguments
-///
-/// * `model` - The Anthropic model identifier (e.g., `"claude-sonnet-4-5"`, `"claude-3-5-sonnet"`)
-///
-/// # Example
-///
-/// ```
-/// use aquaregia::anthropic;
-///
-/// let model = anthropic("claude-sonnet-4-5");
-/// assert_eq!(model.id(), "anthropic/claude-sonnet-4-5");
-/// ```
-pub fn anthropic(model: impl Into<String>) -> ModelRef<Anthropic> {
-    ModelRef::<Anthropic>::new(model)
-}
-
-/// Creates a typed Google model reference (`google/<model>`).
-///
-/// This function provides a convenient way to create a [`ModelRef`] for Google Generative AI models
-/// with compile-time provider type safety.
-///
-/// # Arguments
-///
-/// * `model` - The Google model identifier (e.g., `"gemini-2.0-flash"`, `"gemini-1.5-pro"`)
-///
-/// # Example
-///
-/// ```
-/// use aquaregia::google;
-///
-/// let model = google("gemini-2.0-flash");
-/// assert_eq!(model.id(), "google/gemini-2.0-flash");
-/// ```
-pub fn google(model: impl Into<String>) -> ModelRef<Google> {
-    ModelRef::<Google>::new(model)
-}
-
-/// Creates a typed OpenAI-compatible model reference (`openai-compatible/<model>`).
-///
-/// This function provides a convenient way to create a [`ModelRef`] for OpenAI-compatible
-/// endpoints (e.g., DeepSeek, local LLM servers) with compile-time provider type safety.
-///
-/// # Arguments
-///
-/// * `model` - The model identifier for the compatible endpoint (e.g., `"deepseek-chat"`)
-///
-/// # Example
-///
-/// ```
-/// use aquaregia::openai_compatible;
-///
-/// let model = openai_compatible("deepseek-chat");
-/// assert_eq!(model.id(), "openai-compatible/deepseek-chat");
-/// ```
-pub fn openai_compatible(model: impl Into<String>) -> ModelRef<OpenAiCompatible> {
-    ModelRef::<OpenAiCompatible>::new(model)
-}

--- a/src/model_adapters/mod.rs
+++ b/src/model_adapters/mod.rs
@@ -42,8 +42,6 @@
 //! # }
 //! ```
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use reqwest::Response;
 
@@ -75,9 +73,6 @@ pub trait ModelAdapter<P: ProviderMarker>: Send + Sync {
     /// Executes a streaming text generation call.
     async fn stream_text(&self, req: &GenerateTextRequest<P>) -> Result<TextStream, Error>;
 }
-
-/// Shared adapter object used internally by provider-bound clients.
-pub type SharedAdapter<P> = Arc<dyn ModelAdapter<P>>;
 
 pub(crate) async fn check_response_status(
     provider_id: &str,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,75 +1,13 @@
-//! SSE (Server-Sent Events) frame parsing helpers for Aquaregia streaming.
+//! Internal SSE (Server-Sent Events) frame parsing helpers.
 //!
-//! This module provides utilities for parsing SSE streams from LLM providers:
-//!
-//! - `SseFrame`: Parsed SSE frame with optional event name and data payload
-//! - `parse_sse_lines`: Parse complete SSE data into frames
-//!
-//! ## SSE Format
-//!
-//! Server-Sent Events use a simple text-based format:
-//! ```text
-//! event: message_type
-//! data: {"json": "payload"}
-//!
-//! data: [DONE]
-//!
-//! ```
-//!
-//! Each frame is separated by a blank line (`\n\n`), and fields are prefixed
-//! with `event:`, `data:`, `id:`, or `retry:`.
+//! Used by streaming adapters to drain frames from incrementally received
+//! response bodies. Not exposed to library users.
 
-/// Parsed SSE frame.
-///
-/// This struct represents a single parsed SSE (Server-Sent Events) frame,
-/// containing an optional event name and the data payload.
-///
-/// # Fields
-///
-/// - `event`: Optional event type name (e.g., "message", "done")
-/// - `data`: Data payload, typically JSON for LLM streaming responses
 #[derive(Debug, Clone)]
-pub struct SseFrame {
-    /// Optional SSE event name.
-    pub event: Option<String>,
-    /// Frame payload from one or more `data:` lines.
+pub(crate) struct SseFrame {
     pub data: String,
 }
 
-/// Parses one or more SSE frames from a complete string payload.
-///
-/// This helper normalizes line endings (`\r\n` to `\n`) and ensures a trailing
-/// frame separator so callers can pass chunked test fixtures conveniently.
-///
-/// # Arguments
-///
-/// * `input` - Raw SSE data string containing one or more frames
-///
-/// # Returns
-///
-/// A vector of parsed [`SseFrame`] items. Frames without data are skipped.
-///
-/// # Example
-///
-/// ```
-/// use aquaregia::stream::parse_sse_lines;
-///
-/// let input = "event: message\ndata: {\"text\": \"hello\"}\n\ndata: [DONE]\n\n";
-/// let frames = parse_sse_lines(input);
-///
-/// assert_eq!(frames.len(), 2);
-/// assert_eq!(frames[0].event, Some("message".to_string()));
-/// assert_eq!(frames[1].data, "[DONE]");
-/// ```
-pub fn parse_sse_lines(input: &str) -> Vec<SseFrame> {
-    let mut buffer = input.replace("\r\n", "\n");
-    if !buffer.ends_with("\n\n") {
-        buffer.push_str("\n\n");
-    }
-    drain_sse_frames(&mut buffer)
-}
-
-/// Internal helper to drain parsed frames from a buffer.
 pub(crate) fn drain_sse_frames(buffer: &mut String) -> Vec<SseFrame> {
     let mut out = Vec::new();
     while let Some(idx) = buffer.find("\n\n") {
@@ -82,50 +20,39 @@ pub(crate) fn drain_sse_frames(buffer: &mut String) -> Vec<SseFrame> {
     out
 }
 
-/// Parse a single SSE frame from raw text.
 fn parse_frame(raw: &str) -> Option<SseFrame> {
-    let mut event = None;
     let mut data_lines = Vec::new();
 
     for line in raw.lines() {
-        // Skip comment lines
         if line.starts_with(':') {
             continue;
         }
-
-        // Parse event name
-        if let Some(value) = line.strip_prefix("event:") {
-            event = Some(value.trim().to_string());
-            continue;
-        }
-
-        // Parse data line
         if let Some(value) = line.strip_prefix("data:") {
             data_lines.push(value.trim_start().to_string());
         }
     }
 
-    // Frames without data are invalid
     if data_lines.is_empty() {
         return None;
     }
 
     Some(SseFrame {
-        event,
         data: data_lines.join("\n"),
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::parse_sse_lines;
+    use super::drain_sse_frames;
 
     #[test]
-    fn parses_multiple_frames() {
-        let input = "event: one\ndata: {\"a\":1}\n\ndata: [DONE]\n\n";
-        let frames = parse_sse_lines(input);
+    fn drains_multiple_frames() {
+        let mut buffer =
+            String::from("event: one\ndata: {\"a\":1}\n\ndata: [DONE]\n\nincomplete: tail");
+        let frames = drain_sse_frames(&mut buffer);
         assert_eq!(frames.len(), 2);
-        assert_eq!(frames[0].event.as_deref(), Some("one"));
+        assert_eq!(frames[0].data, "{\"a\":1}");
         assert_eq!(frames[1].data, "[DONE]");
+        assert_eq!(buffer, "incomplete: tail");
     }
 }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -86,7 +86,7 @@ impl std::fmt::Debug for Tool {
 
 impl Tool {
     /// Creates a tool from explicit parts.
-    pub fn from_parts(descriptor: ToolDescriptor, executor: Arc<dyn ToolExecutor>) -> Self {
+    pub(crate) fn from_parts(descriptor: ToolDescriptor, executor: Arc<dyn ToolExecutor>) -> Self {
         Self {
             descriptor,
             executor,
@@ -236,13 +236,13 @@ pub(crate) struct RegisteredTool {
 }
 
 /// Validated registry keyed by tool name.
-pub struct ToolRegistry {
+pub(crate) struct ToolRegistry {
     entries: HashMap<String, RegisteredTool>,
 }
 
 impl ToolRegistry {
     /// Builds a registry and validates names and JSON Schemas.
-    pub fn from_tools(tools: Vec<Tool>) -> Result<Self, Error> {
+    pub(crate) fn from_tools(tools: Vec<Tool>) -> Result<Self, Error> {
         let mut entries = HashMap::new();
         let name_re = Regex::new(r"^[a-zA-Z0-9_-]{1,64}$")
             .expect("tool name regex must be valid at compile time");
@@ -273,16 +273,6 @@ impl ToolRegistry {
         }
 
         Ok(Self { entries })
-    }
-
-    /// Returns a registered tool by name.
-    pub fn get(&self, name: &str) -> Option<&Tool> {
-        self.entries.get(name).map(|entry| &entry.tool)
-    }
-
-    /// Returns all registered tool names.
-    pub fn names(&self) -> Vec<&str> {
-        self.entries.keys().map(String::as_str).collect()
     }
 
     pub(crate) fn resolve(&self, name: &str) -> Option<&RegisteredTool> {
@@ -384,34 +374,6 @@ mod tests {
     }
 
     // ─── ToolRegistry ───────────────────────────────────────────────────
-
-    #[test]
-    fn registry_get_returns_tool_by_name() {
-        let registry = ToolRegistry::from_tools(vec![make_tool("echo")]).unwrap();
-        let tool = registry.get("echo").unwrap();
-        assert_eq!(tool.descriptor.name, "echo");
-    }
-
-    #[test]
-    fn registry_get_returns_none_for_unknown_name() {
-        let registry = ToolRegistry::from_tools(vec![make_tool("echo")]).unwrap();
-        assert!(registry.get("unknown").is_none());
-    }
-
-    #[test]
-    fn registry_names_returns_all_tool_names() {
-        let registry =
-            ToolRegistry::from_tools(vec![make_tool("alpha"), make_tool("beta")]).unwrap();
-        let mut names = registry.names();
-        names.sort();
-        assert_eq!(names, vec!["alpha", "beta"]);
-    }
-
-    #[test]
-    fn registry_empty_names() {
-        let registry = ToolRegistry::from_tools(vec![]).unwrap();
-        assert!(registry.names().is_empty());
-    }
 
     #[test]
     fn registry_rejects_invalid_tool_name_special_chars() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -370,22 +370,6 @@ impl Message {
             name: None,
         }
     }
-
-    /// Creates a user message with text and an image URL.
-    pub fn user_text_and_image_url(text: impl Into<String>, url: impl Into<String>) -> Self {
-        Self {
-            role: MessageRole::User,
-            parts: vec![
-                ContentPart::Text(text.into()),
-                ContentPart::Image(ImagePart {
-                    data: MediaData::Url(url.into()),
-                    media_type: None,
-                    provider_metadata: None,
-                }),
-            ],
-            name: None,
-        }
-    }
 }
 
 /// Raw media data for image content parts.
@@ -1428,13 +1412,6 @@ mod tests {
     fn message_user_image_bytes() {
         let msg = Message::user_image_bytes(vec![0xFF, 0xD8], "image/jpeg");
         assert_eq!(msg.role(), MessageRole::User);
-    }
-
-    #[test]
-    fn message_user_text_and_image_url() {
-        let msg = Message::user_text_and_image_url("caption", "https://example.com/img.jpg");
-        assert_eq!(msg.role(), MessageRole::User);
-        assert_eq!(msg.parts().len(), 2);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,28 +37,6 @@ pub enum ProviderKind {
 }
 
 impl ProviderKind {
-    /// Parses a provider slug (case-insensitive).
-    ///
-    /// This function converts a string identifier into the corresponding [`ProviderKind`] variant.
-    /// The input is normalized to lowercase before matching.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - Provider slug string (e.g., `"openai"`, `"anthropic"`, `"google"`, `"openai-compatible"`)
-    ///
-    /// # Returns
-    ///
-    /// `Some(ProviderKind)` if the slug matches, `None` otherwise.
-    pub fn from_slug(value: &str) -> Option<Self> {
-        match value.to_ascii_lowercase().as_str() {
-            "openai" => Some(Self::OpenAi),
-            "anthropic" => Some(Self::Anthropic),
-            "google" => Some(Self::Google),
-            "openai-compatible" => Some(Self::OpenAiCompatible),
-            _ => None,
-        }
-    }
-
     /// Returns the canonical provider slug.
     ///
     /// This method returns the normalized string identifier for the provider,
@@ -179,16 +157,6 @@ impl<P: ProviderMarker> ModelRef<P> {
     /// suitable for logging, display, or configuration purposes.
     pub fn id(&self) -> String {
         format!("{}/{}", P::KIND.as_slug(), self.model)
-    }
-
-    /// Returns the provider family marker for this model.
-    pub fn provider_kind(&self) -> ProviderKind {
-        P::KIND
-    }
-
-    /// Returns the provider slug for this model.
-    pub fn provider_slug(&self) -> &'static str {
-        P::KIND.as_slug()
     }
 
     /// Returns the provider-local model id.
@@ -358,19 +326,6 @@ impl Message {
         }
     }
 
-    /// Attaches an optional author/tool name to the message.
-    ///
-    /// The name field can be used for attribution purposes,
-    /// such as identifying which tool produced a result.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The author or tool name
-    pub fn with_name(mut self, name: impl Into<String>) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
     /// Returns the message role.
     pub fn role(&self) -> MessageRole {
         self.role.clone()
@@ -379,11 +334,6 @@ impl Message {
     /// Returns message content parts.
     pub fn parts(&self) -> &[ContentPart] {
         &self.parts
-    }
-
-    /// Returns optional message name.
-    pub fn name(&self) -> Option<&str> {
-        self.name.as_deref()
     }
 
     /// Internal constructor for assistant messages with multiple content parts.
@@ -1109,7 +1059,7 @@ impl std::ops::AddAssign for Usage {
 
 impl Usage {
     /// Builds usage from provider totals and back-fills derived counters.
-    pub fn from_totals(
+    pub(crate) fn from_totals(
         input_tokens: u32,
         output_tokens: u32,
         reasoning_tokens: u32,
@@ -1132,7 +1082,7 @@ impl Usage {
     }
 
     /// Sets input cache split and recomputes no-cache input tokens.
-    pub fn with_input_cache_split(
+    pub(crate) fn with_input_cache_split(
         mut self,
         cache_read_tokens: u32,
         cache_write_tokens: u32,
@@ -1147,7 +1097,7 @@ impl Usage {
     }
 
     /// Sets output text/reasoning split and recomputes total output tokens.
-    pub fn with_output_split(mut self, output_text_tokens: u32, reasoning_tokens: u32) -> Self {
+    pub(crate) fn with_output_split(mut self, output_text_tokens: u32, reasoning_tokens: u32) -> Self {
         self.output_text_tokens = output_text_tokens;
         self.reasoning_tokens = reasoning_tokens;
         self.output_tokens = output_text_tokens.saturating_add(reasoning_tokens);
@@ -1156,7 +1106,7 @@ impl Usage {
     }
 
     /// Attaches raw provider usage payload.
-    pub fn with_raw_usage(mut self, raw_usage: Value) -> Self {
+    pub(crate) fn with_raw_usage(mut self, raw_usage: Value) -> Self {
         self.raw_usage = Some(raw_usage);
         self
     }
@@ -1340,7 +1290,6 @@ mod tests {
     #[test]
     fn builds_openai_model() {
         let model = ModelRef::<OpenAi>::new("gpt-4o-mini");
-        assert_eq!(model.provider_kind(), ProviderKind::OpenAi);
         assert_eq!(model.model(), "gpt-4o-mini");
     }
 
@@ -1390,32 +1339,6 @@ mod tests {
     }
 
     // ─── ProviderKind ────────────────────────────────────────────────────
-
-    #[test]
-    fn provider_kind_from_slug_all_variants() {
-        assert_eq!(
-            ProviderKind::from_slug("openai"),
-            Some(ProviderKind::OpenAi)
-        );
-        assert_eq!(
-            ProviderKind::from_slug("ANTHROPIC"),
-            Some(ProviderKind::Anthropic)
-        );
-        assert_eq!(
-            ProviderKind::from_slug("Google"),
-            Some(ProviderKind::Google)
-        );
-        assert_eq!(
-            ProviderKind::from_slug("OpenAI-Compatible"),
-            Some(ProviderKind::OpenAiCompatible)
-        );
-    }
-
-    #[test]
-    fn provider_kind_from_slug_unknown() {
-        assert_eq!(ProviderKind::from_slug("unknown"), None);
-        assert_eq!(ProviderKind::from_slug(""), None);
-    }
 
     #[test]
     fn provider_kind_as_slug() {
@@ -1493,18 +1416,6 @@ mod tests {
         };
         let msg = Message::tool_result(result.clone());
         assert_eq!(msg.role(), MessageRole::Tool);
-    }
-
-    #[test]
-    fn message_with_name() {
-        let msg = Message::user_text("hello").with_name("alice");
-        assert_eq!(msg.name(), Some("alice"));
-    }
-
-    #[test]
-    fn message_name_none_by_default() {
-        let msg = Message::user_text("hello");
-        assert_eq!(msg.name(), None);
     }
 
     #[test]

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use aquaregia::{Agent, AgentPreparedStep, LlmClient, Message, openai, tool};
+use aquaregia::{Agent, AgentPreparedStep, LlmClient, Message, tool};
 use serde_json::json;
 use wiremock::matchers::{body_string_contains, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -36,7 +36,7 @@ async fn agent_run_includes_instructions() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .instructions("You are concise.")
         .build()
         .expect("agent should build");
@@ -127,7 +127,7 @@ async fn agent_tool_loop_works() {
             Ok(json!({ "city": city, "temp_c": 23 }))
         });
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([weather])
         .max_steps(3)
         .build()
@@ -141,54 +141,6 @@ async fn agent_tool_loop_works() {
     assert_eq!(response.output_text, "Shanghai is about 23C.");
     assert_eq!(response.steps, 2);
     assert_eq!(response.usage_total.total_tokens, 27);
-}
-
-#[tokio::test]
-async fn agent_prepare_call_can_override_messages() {
-    let server = MockServer::start().await;
-
-    let body = json!({
-        "choices": [{
-            "message": { "content": "prepared-call-ok" },
-            "finish_reason": "stop"
-        }],
-        "usage": {
-            "prompt_tokens": 5,
-            "completion_tokens": 2,
-            "total_tokens": 7
-        }
-    });
-
-    Mock::given(method("POST"))
-        .and(path("/v1/chat/completions"))
-        .and(body_string_contains("from-prepare-call"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(body))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let client = LlmClient::openai("test-openai-key")
-        .base_url(server.uri())
-        .build()
-        .expect("client should build");
-
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
-        .prepare_call(|plan| {
-            plan.messages = vec![
-                Message::system_text("from-prepare-call"),
-                Message::user_text("hello"),
-            ];
-        })
-        .build()
-        .expect("agent should build");
-
-    let response = agent
-        .run_messages(vec![Message::user_text("ignored")])
-        .await
-        .expect("agent call should succeed");
-
-    assert_eq!(response.output_text, "prepared-call-ok");
-    assert_eq!(response.steps, 1);
 }
 
 #[tokio::test]
@@ -220,7 +172,7 @@ async fn agent_prepare_step_can_override_messages() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .max_steps(1)
         .prepare_step(|event| AgentPreparedStep {
             model: event.model.clone(),
@@ -246,7 +198,7 @@ async fn agent_prepare_step_can_override_messages() {
 }
 
 #[tokio::test]
-async fn agent_prepare_call_can_override_sampling_and_on_start_receives_model_id() {
+async fn agent_prepare_step_can_override_sampling_and_on_start_sees_builder_model() {
     let server = MockServer::start().await;
 
     let body = json!({
@@ -275,20 +227,19 @@ async fn agent_prepare_call_can_override_sampling_and_on_start_receives_model_id
 
     let start_event = Arc::new(Mutex::new(None::<(String, usize, usize, u8)>));
     let start_event_for_hook = Arc::clone(&start_event);
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4.1-mini")
         .max_steps(2)
-        .top_p(0.3)
-        .max_output_tokens(16)
-        .stop_sequences(["STOP"])
-        .prepare_call(|plan| {
-            plan.model = openai("gpt-4.1-mini");
-            plan.messages = vec![
-                Message::system_text("from-prepare-call"),
+        .top_p(0.7)
+        .prepare_step(|event| AgentPreparedStep {
+            model: event.model.clone(),
+            messages: vec![
+                Message::system_text("from-prepare-step"),
                 Message::user_text("hello"),
-            ];
-            plan.top_p = Some(0.7);
-            plan.max_output_tokens = Some(42);
-            plan.stop_sequences = vec!["END".to_string()];
+            ],
+            tools: event.tools.clone(),
+            temperature: event.temperature,
+            max_output_tokens: Some(42),
+            stop_sequences: vec!["END".to_string()],
         })
         .on_start(move |event| {
             *start_event_for_hook
@@ -333,13 +284,13 @@ async fn agent_prepare_call_can_override_sampling_and_on_start_receives_model_id
             .as_array()
             .expect("messages should be an array")
             .iter()
-            .any(|message| message["content"] == "from-prepare-call")
+            .any(|message| message["content"] == "from-prepare-step")
     );
     assert_eq!(
         start_event
             .lock()
             .expect("start_event mutex should not be poisoned")
             .clone(),
-        Some(("openai/gpt-4.1-mini".to_string(), 2, 0, 2))
+        Some(("openai/gpt-4.1-mini".to_string(), 1, 0, 2))
     );
 }

--- a/tests/agent_edge.rs
+++ b/tests/agent_edge.rs
@@ -1,4 +1,4 @@
-use aquaregia::{Agent, AgentPreparedStep, ErrorCode, LlmClient, Message, ToolErrorPolicy, openai};
+use aquaregia::{Agent, AgentPreparedStep, ErrorCode, LlmClient, Message, ToolErrorPolicy};
 use serde_json::json;
 use wiremock::matchers::{body_string_contains, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -48,7 +48,7 @@ async fn agent_max_steps_exceeded() {
         .description("dummy")
         .execute_raw(|_args| async move { Ok(json!({"ok": true})) });
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([dummy])
         .max_steps(3)
         .build()
@@ -88,7 +88,7 @@ async fn agent_stop_when_predicate_stops_early() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .max_steps(5)
         .stop_when(|step| step.output_text.contains("First"))
         .build()
@@ -148,7 +148,7 @@ async fn agent_fail_fast_on_invalid_tool_args() {
         }))
         .execute_raw(|args| async move { Ok(json!({"city": args["city"], "temp": 22})) });
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([weather])
         .max_steps(3)
         .tool_error_policy(ToolErrorPolicy::FailFast)
@@ -226,7 +226,7 @@ async fn agent_continue_on_invalid_tool_args() {
         }))
         .execute_raw(|args| async move { Ok(json!({"city": args["city"], "temp": 22})) });
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([weather])
         .max_steps(3)
         .tool_error_policy(ToolErrorPolicy::ContinueAsToolResult)
@@ -265,7 +265,7 @@ async fn agent_without_tools_returns_first_response() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .max_steps(5)
         .build()
         .expect("agent should build");
@@ -303,7 +303,7 @@ async fn agent_run_messages_uses_explicit_message_list() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .build()
         .expect("agent should build");
 
@@ -344,7 +344,7 @@ async fn agent_respects_existing_system_message() {
 
     // With agent instructions set AND an explicit system message,
     // the explicit system message should take precedence over agent instructions.
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .instructions("agent-level-instruction")
         .build()
         .expect("agent should build");
@@ -388,7 +388,7 @@ async fn agent_prepare_step_changes_tools() {
         .description("dummy")
         .execute_raw(|_args| async move { Ok(json!({"ok": true})) });
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([dummy])
         .max_steps(5)
         .prepare_step(|event| AgentPreparedStep {

--- a/tests/cancellation.rs
+++ b/tests/cancellation.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use aquaregia::{
     Agent, CancellationToken, ErrorCode, GenerateTextRequest, LlmClient, Tool, ToolDescriptor,
-    ToolExecError, ToolExecutor, openai,
+    ToolExecError, ToolExecutor,
 };
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -24,7 +24,7 @@ async fn cancel_before_request_fires() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::builder(openai("gpt-4o-mini"))
+    let req = GenerateTextRequest::builder("gpt-4o-mini")
         .user_prompt("hello")
         .cancellation_token(token)
         .build()
@@ -53,13 +53,14 @@ async fn cancel_before_agent_step() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .max_steps(3)
+        .cancellation_token(token)
         .build()
         .expect("agent should build");
 
     let err = agent
-        .run_cancellable("hello", token)
+        .run("hello")
         .await
         .expect_err("should fail with Cancelled");
 
@@ -124,14 +125,15 @@ async fn cancel_between_agent_steps() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([cancel_tool])
         .max_steps(5)
+        .cancellation_token(token)
         .build()
         .expect("agent should build");
 
     let err = agent
-        .run_cancellable("go", token)
+        .run("go")
         .await
         .expect_err("should fail with Cancelled");
 

--- a/tests/error_mapping.rs
+++ b/tests/error_mapping.rs
@@ -1,9 +1,9 @@
-use aquaregia::{ErrorCode, GenerateTextRequest, LlmClient, Message, anthropic};
+use aquaregia::{ErrorCode, GenerateTextRequest, LlmClient, Message};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn anthropic_request() -> GenerateTextRequest<aquaregia::Anthropic> {
-    GenerateTextRequest::builder(anthropic("claude-3-5-haiku-latest"))
+    GenerateTextRequest::builder("claude-3-5-haiku-latest")
         .message(Message::user_text("hi"))
         .temperature(0.2)
         .max_output_tokens(32)

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -1,10 +1,10 @@
-use aquaregia::{ErrorCode, GenerateTextRequest, LlmClient, Message, OpenAi, openai};
+use aquaregia::{ErrorCode, GenerateTextRequest, LlmClient, Message, OpenAi};
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn openai_request() -> GenerateTextRequest<OpenAi> {
-    GenerateTextRequest::builder(openai("gpt-4o-mini"))
+    GenerateTextRequest::builder("gpt-4o-mini")
         .message(Message::user_text("hello"))
         .temperature(0.2)
         .max_output_tokens(64)

--- a/tests/providers.rs
+++ b/tests/providers.rs
@@ -1,4 +1,4 @@
-use aquaregia::{GenerateTextRequest, LlmClient, anthropic, google, openai_compatible};
+use aquaregia::{GenerateTextRequest, LlmClient};
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -40,7 +40,7 @@ async fn google_generate_text_success() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            google("gemini-2.0-flash"),
+            "gemini-2.0-flash",
             "hello",
         ))
         .await
@@ -96,7 +96,7 @@ async fn openai_compatible_generate_text_success() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            openai_compatible("deepseek-chat"),
+            "deepseek-chat",
             "hello",
         ))
         .await
@@ -146,7 +146,7 @@ async fn openai_compatible_generate_keeps_think_tags_by_default() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            openai_compatible("deepseek-chat"),
+            "deepseek-chat",
             "hello",
         ))
         .await
@@ -193,7 +193,7 @@ async fn openai_compatible_generate_splits_think_tags_when_enabled() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            openai_compatible("deepseek-chat"),
+            "deepseek-chat",
             "hello",
         ))
         .await
@@ -241,7 +241,7 @@ async fn openai_compatible_generate_prefers_standard_reasoning_field() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            openai_compatible("deepseek-chat"),
+            "deepseek-chat",
             "hello",
         ))
         .await
@@ -293,7 +293,7 @@ async fn anthropic_generate_text_usage_parses_cache_and_iterations() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            anthropic("claude-3-5-haiku-latest"),
+            "claude-3-5-haiku-latest",
             "hello",
         ))
         .await

--- a/tests/providers_deep.rs
+++ b/tests/providers_deep.rs
@@ -1,7 +1,4 @@
-use aquaregia::{
-    ErrorCode, FinishReason, GenerateTextRequest, LlmClient, Message, StreamEvent, anthropic,
-    google, openai,
-};
+use aquaregia::{ErrorCode, FinishReason, GenerateTextRequest, LlmClient, Message, StreamEvent};
 use futures_util::StreamExt;
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
@@ -31,7 +28,7 @@ async fn google_stream_emits_text_usage_done() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::from_user_prompt(google("gemini-2.0-flash"), "hello");
+    let req = GenerateTextRequest::from_user_prompt("gemini-2.0-flash", "hello");
 
     let mut stream = client
         .stream(req)
@@ -84,7 +81,7 @@ async fn google_stream_with_reasoning() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::from_user_prompt(google("gemini-2.0-flash"), "hello");
+    let req = GenerateTextRequest::from_user_prompt("gemini-2.0-flash", "hello");
 
     let mut stream = client
         .stream(req)
@@ -153,7 +150,7 @@ async fn google_generate_with_reasoning() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            google("gemini-2.0-flash"),
+            "gemini-2.0-flash",
             "hello",
         ))
         .await
@@ -207,7 +204,7 @@ async fn google_generate_with_tool_calls() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            google("gemini-2.0-flash"),
+            "gemini-2.0-flash",
             "weather?",
         ))
         .await
@@ -258,7 +255,7 @@ async fn google_generate_with_thought_signature() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            google("gemini-2.0-flash"),
+            "gemini-2.0-flash",
             "think",
         ))
         .await
@@ -294,7 +291,7 @@ async fn google_503_maps_to_provider_server_error() {
 
     let err = client
         .generate(GenerateTextRequest::from_user_prompt(
-            google("gemini-2.0-flash"),
+            "gemini-2.0-flash",
             "hello",
         ))
         .await
@@ -324,7 +321,7 @@ async fn google_invalid_response_missing_candidates() {
 
     let err = client
         .generate(GenerateTextRequest::from_user_prompt(
-            google("gemini-2.0-flash"),
+            "gemini-2.0-flash",
             "hello",
         ))
         .await
@@ -366,7 +363,7 @@ async fn anthropic_stream_with_thinking() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::builder(anthropic("claude-3-5-haiku-latest"))
+    let req = GenerateTextRequest::builder("claude-3-5-haiku-latest")
         .message(Message::user_text("hello"))
         .temperature(0.2)
         .max_output_tokens(128)
@@ -427,7 +424,7 @@ async fn openai_stream_with_reasoning_delta() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::builder(openai("gpt-4o-mini"))
+    let req = GenerateTextRequest::builder("gpt-4o-mini")
         .message(Message::user_text("hello"))
         .temperature(0.2)
         .max_output_tokens(128)
@@ -485,7 +482,7 @@ async fn openai_stream_with_tool_calls_and_finish() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::builder(openai("gpt-4o-mini"))
+    let req = GenerateTextRequest::builder("gpt-4o-mini")
         .message(Message::user_text("weather?"))
         .temperature(0.2)
         .max_output_tokens(128)
@@ -554,7 +551,7 @@ async fn openai_generate_with_reasoning() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            openai("gpt-4o-mini"),
+            "gpt-4o-mini",
             "hello",
         ))
         .await
@@ -608,7 +605,7 @@ async fn openai_generate_with_tool_calls() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            openai("gpt-4o-mini"),
+            "gpt-4o-mini",
             "weather?",
         ))
         .await
@@ -664,7 +661,7 @@ async fn anthropic_generate_with_thinking_and_tool_use() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            anthropic("claude-3-5-haiku-latest"),
+            "claude-3-5-haiku-latest",
             "weather?",
         ))
         .await
@@ -715,7 +712,7 @@ async fn anthropic_generate_with_redacted_thinking() {
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
-            anthropic("claude-3-5-haiku-latest"),
+            "claude-3-5-haiku-latest",
             "hello",
         ))
         .await
@@ -748,7 +745,7 @@ async fn anthropic_invalid_response_missing_content() {
 
     let err = client
         .generate(GenerateTextRequest::from_user_prompt(
-            anthropic("claude-3-5-haiku-latest"),
+            "claude-3-5-haiku-latest",
             "hello",
         ))
         .await
@@ -776,7 +773,7 @@ async fn anthropic_500_maps_to_provider_server_error() {
 
     let err = client
         .generate(GenerateTextRequest::from_user_prompt(
-            anthropic("claude-3-5-haiku-latest"),
+            "claude-3-5-haiku-latest",
             "hello",
         ))
         .await
@@ -805,7 +802,7 @@ async fn openai_403_maps_to_auth_failed() {
 
     let err = client
         .generate(GenerateTextRequest::from_user_prompt(
-            openai("gpt-4o-mini"),
+            "gpt-4o-mini",
             "hello",
         ))
         .await
@@ -836,7 +833,7 @@ async fn openai_invalid_response_missing_choices() {
 
     let err = client
         .generate(GenerateTextRequest::from_user_prompt(
-            openai("gpt-4o-mini"),
+            "gpt-4o-mini",
             "hello",
         ))
         .await

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,6 +1,4 @@
-use aquaregia::{
-    GenerateTextRequest, LlmClient, Message, StreamEvent, anthropic, openai, openai_compatible,
-};
+use aquaregia::{GenerateTextRequest, LlmClient, Message, StreamEvent};
 use futures_util::StreamExt;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -31,7 +29,7 @@ async fn anthropic_stream_emits_text_usage_done() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::builder(anthropic("claude-3-5-haiku-latest"))
+    let req = GenerateTextRequest::builder("claude-3-5-haiku-latest")
         .message(Message::user_text("hello"))
         .temperature(0.2)
         .max_output_tokens(32)
@@ -104,7 +102,7 @@ async fn openai_stream_accepts_eof_without_done_marker() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::builder(openai("gpt-4o-mini"))
+    let req = GenerateTextRequest::builder("gpt-4o-mini")
         .message(Message::user_text("hello"))
         .temperature(0.2)
         .max_output_tokens(32)
@@ -176,7 +174,7 @@ async fn openai_compatible_stream_accepts_eof_without_done_or_finish_reason() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::builder(openai_compatible("demo-model"))
+    let req = GenerateTextRequest::builder("demo-model")
         .message(Message::user_text("hello"))
         .temperature(0.2)
         .max_output_tokens(32)
@@ -250,7 +248,7 @@ async fn openai_compatible_stream_splits_think_tags_when_enabled() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::builder(openai_compatible("demo-model"))
+    let req = GenerateTextRequest::builder("demo-model")
         .message(Message::user_text("hello"))
         .temperature(0.2)
         .max_output_tokens(32)
@@ -309,7 +307,7 @@ async fn openai_compatible_stream_prefers_standard_reasoning_field() {
         .build()
         .expect("client should build");
 
-    let req = GenerateTextRequest::builder(openai_compatible("demo-model"))
+    let req = GenerateTextRequest::builder("demo-model")
         .message(Message::user_text("hello"))
         .temperature(0.2)
         .max_output_tokens(32)

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use aquaregia::{
     Agent, AgentPreparedStep, ErrorCode, LlmClient, Message, Tool, ToolDescriptor, ToolExecError,
-    ToolExecutor, openai,
+    ToolExecutor,
 };
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -100,7 +100,7 @@ async fn run_tools_two_step_success() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([make_weather_tool()])
         .max_steps(3)
         .temperature(0.2)
@@ -156,7 +156,7 @@ async fn run_tools_unknown_tool_fails() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([make_weather_tool()])
         .max_steps(3)
         .build()
@@ -240,7 +240,7 @@ async fn run_tools_lifecycle_hooks_fire() {
 
     let agent = {
         let e = Arc::clone(&events);
-        let agent = Agent::builder(client, openai("gpt-4o-mini"))
+        let agent = Agent::builder(client, "gpt-4o-mini")
             .tools([make_weather_tool()])
             .max_steps(3)
             .temperature(0.2)
@@ -339,7 +339,7 @@ async fn run_tools_prepare_step_can_override_step_input() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .max_steps(1)
         .prepare_step(|event| AgentPreparedStep {
             model: event.model.clone(),
@@ -439,7 +439,7 @@ async fn tool_calls_execute_in_parallel() {
         .build()
         .expect("client should build");
 
-    let agent = Agent::builder(client, openai("gpt-4o-mini"))
+    let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([slow_tool])
         .max_steps(3)
         .build()


### PR DESCRIPTION
## Summary

Two-wave cleanup of the public API. Net ~21 pub names removed, ~452 lines of source deleted, 0 external usages affected.

### Wave 1 — `5811cd3` shrink public API by removing unused surface

10 names with **zero references** in `examples/`, `tests/`, or `README*.md`.

**Removed entirely**: `stream::parse_sse_lines` + `SseFrame::event` field, `ToolRegistry::get/names`, `ProviderKind::from_slug`, `ModelRef::provider_kind/provider_slug`, `Message::with_name/name`, `model_adapters::SharedAdapter` type alias.

**Downgraded to `pub(crate)`** (internal-only, still used by adapters/client): `stream` module + `SseFrame`, `ToolRegistry` + `from_tools`, `Tool::from_parts`, `Usage::{from_totals, with_input_cache_split, with_output_split, with_raw_usage}`, `Error::{with_request_id, with_raw_body}`, `error::{classify_http_error, is_retryable}`.

`ModelAdapter` trait stays `pub` because the `pub trait ProviderBinding` references it in its signature; downgrading would trip E0445.

### Wave 2 — `f0558c3` collapse 4 breaking-change API duplications

**`Agent::run_*` methods**: removed `run_cancellable` and `run_messages_cancellable`. The `(prompt|messages) × (cancellable|non)` Cartesian product collapses to two methods. Cancellation now binds at builder time via `AgentBuilder::cancellation_token(token)` so each agent owns its lifetime. Per-call cancellation is still available on `GenerateTextRequestBuilder` for raw `generate`/`stream`.

**Agent dynamic planning**: removed `prepare_call` hook and the `AgentRunPlan` public type. `prepare_step` (per-step, returns `AgentPreparedStep`) subsumes `prepare_call` when applied at `step == 1`; `top_p`, which `prepare_step` cannot reach, goes on the builder.

**Top-level model helpers**: removed `pub fn openai/anthropic/google/openai_compatible`. They were thin wrappers over `ModelRef::<P>::new`, and `&str` already implements `IntoModelRef<P>`. `Agent::builder(client, "gpt-4o")` works directly; provider type `P` is inferred from `BoundClient<P>`.

**Message constructors**: removed `Message::user_text_and_image_url`. It only covered (text + URL image); (text + bytes image), (2 images), and other mixes had no helper. Callers should use `Message::new(MessageRole::User, vec![Text, Image, ...])` for consistency. The two single-image helpers (`user_image_url`, `user_image_bytes`) stay.

README, README_CN, examples, and tests updated accordingly.

## Test plan

- [x] `cargo check --all-features --tests --examples` clean
- [x] `cargo test --all-features` — 227 tests pass
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [ ] Spot-check README rendering on GitHub