### PR TITLE
chore: trim cargo package contents (-32%)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,20 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/minorcell/aquaregia"
 documentation = "https://docs.rs/aquaregia"
+exclude = [
+    ".gitignore",
+    ".github/**",
+    "scripts/**",
+    "codecov.yml",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md",
+    "SECURITY.md",
+    "README_CN.md",
+    "tests/**",
+    "examples/**",
+    "**/AGENTS.md",
+    "**/CLAUDE.md",
+]
 
 [lib]
 name = "aquaregia"


### PR DESCRIPTION
## Summary

\`cargo package\` now ships only what downstream users actually need. Independent of the API cleanup in #26 — this PR only touches \`Cargo.toml\`.

\`.crate\` shrinks from **~105 KiB → 71.5 KiB (-32%)**, 53 files → 19.

### Excluded

- \`tests/\` and \`examples/\` — downstream \`cargo test\` / \`cargo run --example\` doesn't reach files inside a \`.crate\`
- All \`AGENTS.md\` and \`CLAUDE.md\` files — internal AI agent guides, useless to consumers
- \`README_CN.md\` — \`crates.io\` only renders the \`readme\` field
- \`.github/\`, \`scripts/\`, \`codecov.yml\`, \`.gitignore\` — CI / repo plumbing
- \`CONTRIBUTING.md\`, \`CODE_OF_CONDUCT.md\`, \`SECURITY.md\` — governance docs; GitHub renders them in place, no value from inside a \`.crate\`

### Retained

\`src/\`, \`Cargo.toml\`, \`Cargo.lock\`, \`README.md\`, \`LICENSE\`, \`.cargo_vcs_info.json\` — the minimum needed to compile and discover the crate.

### Known cosmetic side-effect

\`cargo publish\` will print 18 warnings like:
\`\`\`
warning: ignoring example \`agent_minimal\` as \`examples/agent_minimal.rs\` is not included in the published package
warning: ignoring test \`providers_deep\` ...
\`\`\`

Reason: Cargo auto-discovers \`[[test]]\` / \`[[example]]\` targets from \`tests/\` and \`examples/\`, then complains when \`exclude\` removes the source files. Cosmetic only — publish still succeeds, downstream users never see this. Disabling auto-discovery (\`autotests = false\` + \`autoexamples = false\`) would require manually declaring 18 \`[[test]]/[[example]]\` sections, which is not worth it.

Local \`cargo test\` and \`cargo run --example\` are unaffected — \`exclude\` only filters \`cargo package\` output.

## Test plan

- [x] \`cargo package --no-verify\` succeeds; \`.crate\` is 71.5 KiB / 19 files
- [x] \`tar -tzf target/package/aquaregia-0.1.8.crate\` confirms only intended files
- [x] \`cargo test --all-features\` still runs all 227 integration tests locally
- [x] \`cargo run --example basic_generate\` etc. still work locally