### PR TITLE
style: unblock CI (rustfmt + collapsible_match)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -455,10 +455,7 @@ mod tests {
             .base_url("https://api.openai.com")
             .build()
             .expect("client should build");
-        let err = match Agent::builder(client, "gpt-4o-mini")
-            .top_p(1.5)
-            .build()
-        {
+        let err = match Agent::builder(client, "gpt-4o-mini").top_p(1.5).build() {
             Ok(_) => panic!("agent build should fail"),
             Err(err) => err,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,7 @@ pub use model_adapters::openai::OpenAiAdapterSettings;
 pub use model_adapters::openai_compatible::OpenAiCompatibleAdapterSettings;
 pub use tokio_util::sync::CancellationToken;
 
-pub use tool::{
-    IntoTool, Tool, ToolBuilder, ToolDescriptor, ToolExecError, ToolExecutor, tool,
-};
+pub use tool::{IntoTool, Tool, ToolBuilder, ToolDescriptor, ToolExecError, ToolExecutor, tool};
 pub use types::{
     AgentFinish,
     AgentPrepareStep,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1081,7 +1081,11 @@ impl Usage {
     }
 
     /// Sets output text/reasoning split and recomputes total output tokens.
-    pub(crate) fn with_output_split(mut self, output_text_tokens: u32, reasoning_tokens: u32) -> Self {
+    pub(crate) fn with_output_split(
+        mut self,
+        output_text_tokens: u32,
+        reasoning_tokens: u32,
+    ) -> Self {
         self.output_text_tokens = output_text_tokens;
         self.reasoning_tokens = reasoning_tokens;
         self.output_tokens = output_text_tokens.saturating_add(reasoning_tokens);

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -48,22 +48,19 @@ async fn anthropic_stream_emits_text_usage_done() {
     while let Some(event) = stream.next().await {
         let event = event.expect("stream event should parse");
         match event {
-            StreamEvent::TextDelta { text } => {
-                if text == "Hello" {
-                    saw_text = true;
-                }
+            StreamEvent::TextDelta { text } if text == "Hello" => {
+                saw_text = true;
             }
-            StreamEvent::Usage { usage } => {
+            StreamEvent::Usage { usage }
                 if usage.input_tokens == 10
                     && usage.input_no_cache_tokens == 7
                     && usage.input_cache_read_tokens == 2
                     && usage.input_cache_write_tokens == 1
                     && usage.output_tokens == 3
                     && usage.output_text_tokens == 3
-                    && usage.total_tokens == 13
-                {
-                    saw_usage = true;
-                }
+                    && usage.total_tokens == 13 =>
+            {
+                saw_usage = true;
             }
             StreamEvent::Done => {
                 saw_done = true;
@@ -121,21 +118,18 @@ async fn openai_stream_accepts_eof_without_done_marker() {
     while let Some(event) = stream.next().await {
         let event = event.expect("stream event should parse");
         match event {
-            StreamEvent::TextDelta { text } => {
-                if text == "Hello" {
-                    saw_text = true;
-                }
+            StreamEvent::TextDelta { text } if text == "Hello" => {
+                saw_text = true;
             }
-            StreamEvent::Usage { usage } => {
+            StreamEvent::Usage { usage }
                 if usage.total_tokens == 5
                     && usage.input_cache_read_tokens == 1
                     && usage.input_no_cache_tokens == 1
                     && usage.output_tokens == 3
                     && usage.output_text_tokens == 2
-                    && usage.reasoning_tokens == 1
-                {
-                    saw_usage = true;
-                }
+                    && usage.reasoning_tokens == 1 =>
+            {
+                saw_usage = true;
             }
             StreamEvent::Done => {
                 saw_done = true;
@@ -193,21 +187,18 @@ async fn openai_compatible_stream_accepts_eof_without_done_or_finish_reason() {
     while let Some(event) = stream.next().await {
         let event = event.expect("stream event should parse");
         match event {
-            StreamEvent::TextDelta { text } => {
-                if text == "Hi" {
-                    saw_text = true;
-                }
+            StreamEvent::TextDelta { text } if text == "Hi" => {
+                saw_text = true;
             }
-            StreamEvent::Usage { usage } => {
+            StreamEvent::Usage { usage }
                 if usage.total_tokens == 5
                     && usage.input_cache_read_tokens == 1
                     && usage.input_no_cache_tokens == 1
                     && usage.output_tokens == 3
                     && usage.output_text_tokens == 2
-                    && usage.reasoning_tokens == 1
-                {
-                    saw_usage = true;
-                }
+                    && usage.reasoning_tokens == 1 =>
+            {
+                saw_usage = true;
             }
             StreamEvent::Done => {
                 saw_done = true;


### PR DESCRIPTION
## Summary

CI's Quality job was failing on \`main\` after PR #26 / #27 for two reasons:

1. **\`cargo fmt --check\` failures**: re-export line in \`src/lib.rs\`, a builder-chain \`match\` in \`src/agent.rs\`, and a long fn signature in \`src/types.rs\` were not normalized after the API cleanup.
2. **\`cargo clippy --all-targets --all-features -- -D warnings\` failures**: Rust 1.95 stabilized the \`collapsible_match\` lint. Six sites in \`tests/stream.rs\` pattern-match a \`StreamEvent\` then re-check a payload field inside the arm — collapsed into match guards.

No behavior change.

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy --all-targets --all-features --locked -- -D warnings\` clean
- [x] \`cargo test --all-features --locked\` — 227 tests pass
- [x] All CI jobs green on this PR