### PR TITLE
ci: pin Rust toolchain to 1.92.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
     "examples/**",
     "**/AGENTS.md",
     "**/CLAUDE.md",
+    "rust-toolchain.toml",
 ]
 
 [lib]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.92.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Adds `rust-toolchain.toml` pinning to `1.92.0` with `rustfmt` and `clippy` components
- Ensures local dev and CI both run the same compiler version, eliminating the toolchain-drift issue documented in #29
- Excludes `rust-toolchain.toml` from the published crate (dev artifact only)

## Related

Closes part of #29 (option 1 of 4).
Branch protection (option 4) requires a separate manual step in GitHub Settings.