### PR TITLE
refactor: remove ProviderMarker, drop unused deps, lean API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,5 @@ jobs:
       - name: Check without default features
         run: cargo check --locked --no-default-features
 
-      - name: Check OpenAI-only feature set
-        run: cargo check --locked --no-default-features --features openai
-
-      - name: Check Anthropic-only feature set
-        run: cargo check --locked --no-default-features --features anthropic
-
       - name: Check telemetry feature set
         run: cargo check --locked --features telemetry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,29 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 - Prefer guidance that explains how to reason about the system over guidance that attempts to mirror the system exhaustively.
 - If examples are needed, keep them short and illustrative rather than comprehensive.
 
+## 7. Lean API Design
+
+**Type-level machinery must earn its complexity.**
+
+Every generic parameter, marker trait, phantom type, or feature flag that ends up in user-facing code costs the user cognitive overhead every time they write a type annotation or read an error message. Add that cost only when there is a concrete, demonstrable benefit.
+
+Before adding type-level structure, ask:
+
+- Does this prevent a real class of mistakes that a clear runtime error would not catch?
+- Does this enable real code reuse — not just the appearance of a unified interface?
+- Can a user realistically misuse the API without this constraint, and would the failure be silent?
+
+If the answers are "no", the abstraction is decorative. Remove it.
+
+Concrete rules for this codebase:
+
+- No phantom type parameters on public structs unless they enforce a boundary that the construction site cannot enforce.
+- No feature flags that gate no code (`openai = []` is noise, not a feature).
+- No trait hierarchies where each implementor does something entirely different — four `impl`s with no shared runtime behaviour is not polymorphism, it is a dispatch table in disguise.
+- No extra wrapper types when a plain value type (`String`, a struct with named fields) communicates the same contract.
+
+The test: if removing the abstraction requires no user-side code changes beyond dropping a type annotation, it was not carrying its weight.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,20 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "serde",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,12 +17,9 @@ version = "0.1.8"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
  "futures-core",
  "futures-util",
  "http",
- "jsonschema",
- "regex",
  "reqwest",
  "schemars",
  "serde",
@@ -45,7 +28,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "url",
  "wiremock",
 ]
 
@@ -99,31 +81,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -132,22 +93,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "borrow-or-share"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -213,47 +162,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "email_address"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "fancy-regex"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fluent-uri"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
-dependencies = [
- "borrow-or-share",
- "ref-cast",
- "serde",
-]
 
 [[package]]
 name = "fnv"
@@ -268,16 +186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fraction"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
-dependencies = [
- "lazy_static",
- "num",
 ]
 
 [[package]]
@@ -670,32 +578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonschema"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
-dependencies = [
- "ahash",
- "base64",
- "bytecount",
- "email_address",
- "fancy-regex",
- "fraction",
- "idna",
- "itoa",
- "num-cmp",
- "num-traits",
- "once_cell",
- "percent-encoding",
- "referencing",
- "regex",
- "regex-syntax",
- "serde",
- "serde_json",
- "uuid-simd",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,15 +594,6 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -752,85 +625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-cmp"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,35 +639,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1011,49 +776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "referencing"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
-dependencies = [
- "ahash",
- "fluent-uri",
- "once_cell",
- "parking_lot",
- "percent-encoding",
- "serde_json",
 ]
 
 [[package]]
@@ -1216,12 +938,6 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -1565,39 +1281,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "uuid"
-version = "1.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "uuid-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
-dependencies = [
- "outref",
- "uuid",
- "vsimd",
-]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,6 @@ name = "aquaregia"
 path = "src/lib.rs"
 
 [features]
-default = ["openai", "anthropic"]
-openai = []
-anthropic = []
 telemetry = ["dep:tracing"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,9 @@ telemetry = ["dep:tracing"]
 [dependencies]
 
 async-stream = "0.3"
-base64 = "0.22"
 async-trait = "0.1"
 futures-core = "0.3"
 futures-util = "0.3"
-jsonschema = { version = "0.30", default-features = false }
-regex = "1.11"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -50,7 +47,6 @@ thiserror = "2.0"
 tokio = { version = "1.44", features = ["macros", "rt-multi-thread", "time"] }
 tokio-util = { version = "0.7" }
 tracing = { version = "0.1", optional = true }
-url = "2.5"
 
 [dev-dependencies]
 http = "1"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You also need a Tokio runtime in your project.
 
 ## Providers
 
-Pick a constructor; the resulting `BoundClient<P>` is parameterized over the provider marker `P`.
+Pick a constructor to get a `BoundClient` for that provider.
 
 | Provider          | Constructor                                              | Model argument        |
 | ----------------- | -------------------------------------------------------- | --------------------- |
@@ -83,21 +83,13 @@ let client = LlmClient::openai(std::env::var("OPENAI_API_KEY")?)
     .build()?;
 ```
 
-### Typed `ModelRef<P>`
+### Model references
 
-To prevent passing an OpenAI model name to an Anthropic client at runtime, use the typed factory helpers:
+`GenerateTextRequest::from_user_prompt` and `.builder()` accept any `impl Into<ModelRef>` — a bare `&str` is the most common form:
 
 ```rust
-use aquaregia::{anthropic, openai, Anthropic, ModelRef, OpenAi};
-
-let gpt:    ModelRef<OpenAi>    = openai("gpt-4o");
-let claude: ModelRef<Anthropic> = anthropic("claude-sonnet-4-5");
-
-// `client_openai.generate(GenerateTextRequest::from_user_prompt(claude, "..."))`
-// is a compile-time error against a `BoundClient<OpenAi>`.
+let req = GenerateTextRequest::from_user_prompt("gpt-4o", "Hello!");
 ```
-
-`GenerateTextRequest::from_user_prompt` accepts anything implementing `IntoModelRef<P>` — a bare `&str` for ergonomic inline calls, or the typed factories above for stronger guarantees.
 
 ### OpenAI-compatible deep configuration
 
@@ -488,7 +480,7 @@ Every `Error` carries a `retryable: bool` flag matching the same classification,
 Aquaregia intentionally keeps web framework adapters out of the crate. If you're building on Axum, adapt `TextStream` in your application layer:
 
 ```rust
-use aquaregia::{BoundClient, GenerateTextRequest, OpenAiCompatible, StreamEvent, TextStream};
+use aquaregia::{BoundClient, GenerateTextRequest, StreamEvent, TextStream};
 use axum::{
     extract::State,
     response::{
@@ -525,7 +517,7 @@ fn to_axum_sse(
     }))
 }
 
-async fn chat(State(client): State<Arc<BoundClient<OpenAiCompatible>>>) -> impl IntoResponse {
+async fn chat(State(client): State<Arc<BoundClient>>) -> impl IntoResponse {
     let stream = client
         .stream(GenerateTextRequest::from_user_prompt("deepseek-chat", "Hello."))
         .await

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,7 +60,7 @@ cargo add aquaregia
 
 ## Providers
 
-选择一个构造器，得到的 `BoundClient<P>` 以 provider marker `P` 为类型参数。
+选择一个构造器，获得该 provider 对应的 `BoundClient`。
 
 | Provider          | 构造器                                                | 模型参数              |
 | ----------------- | ----------------------------------------------------- | --------------------- |
@@ -83,21 +83,13 @@ let client = LlmClient::openai(std::env::var("OPENAI_API_KEY")?)
     .build()?;
 ```
 
-### 类型安全的 `ModelRef<P>`
+### 模型引用
 
-如果你担心把 OpenAI 的模型名错传给 Anthropic 客户端，使用类型化工厂函数：
+`GenerateTextRequest::from_user_prompt` 和 `.builder()` 接受任何 `impl Into<ModelRef>` —— 最常用的是裸 `&str`：
 
 ```rust
-use aquaregia::{anthropic, openai, Anthropic, ModelRef, OpenAi};
-
-let gpt:    ModelRef<OpenAi>    = openai("gpt-4o");
-let claude: ModelRef<Anthropic> = anthropic("claude-sonnet-4-5");
-
-// `client_openai.generate(GenerateTextRequest::from_user_prompt(claude, "..."))`
-// 对 `BoundClient<OpenAi>` 是编译错误。
+let req = GenerateTextRequest::from_user_prompt("gpt-4o", "Hello!");
 ```
-
-`GenerateTextRequest::from_user_prompt` 接受任何实现 `IntoModelRef<P>` 的值 —— 包括裸 `&str`（便捷写法），或上面这些类型化工厂函数（更强保证）。
 
 ### OpenAI-compatible 深度配置
 
@@ -487,7 +479,7 @@ Aquaregia 会在瞬时错误（`RateLimited`、`ProviderServerError`、`Transpor
 Aquaregia 有意不在主 crate 中内置 Web 框架适配层。如果你在用 Axum，可以在应用代码里自行把 `TextStream` 转成 SSE：
 
 ```rust
-use aquaregia::{BoundClient, GenerateTextRequest, OpenAiCompatible, StreamEvent, TextStream};
+use aquaregia::{BoundClient, GenerateTextRequest, StreamEvent, TextStream};
 use axum::{
     extract::State,
     response::{
@@ -524,7 +516,7 @@ fn to_axum_sse(
     }))
 }
 
-async fn chat(State(client): State<Arc<BoundClient<OpenAiCompatible>>>) -> impl IntoResponse {
+async fn chat(State(client): State<Arc<BoundClient>>) -> impl IntoResponse {
     let stream = client
         .stream(GenerateTextRequest::from_user_prompt("deepseek-chat", "你好。"))
         .await

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,10 @@ coverage:
       default:
         target: auto
         threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 2%
 
 ignore:
   - "examples/**"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -48,8 +48,8 @@ use crate::client::BoundClient;
 use crate::tool::{IntoTool, Tool};
 use crate::types::{
     AgentFinish, AgentPrepareStep, AgentPreparedStep, AgentResponse, AgentStart, AgentStep,
-    AgentStepStart, AgentToolCallFinish, AgentToolCallStart, Hook, IntoModelRef, Message, ModelRef,
-    PrepareStepHook, ProviderMarker, RunTools, StopPredicate, ToolErrorPolicy, validate_max_steps,
+    AgentStepStart, AgentToolCallFinish, AgentToolCallStart, Hook, Message, ModelRef,
+    PrepareStepHook, RunTools, StopPredicate, ToolErrorPolicy, validate_max_steps,
     validate_model_ref, validate_sampling,
 };
 
@@ -72,9 +72,9 @@ use crate::types::{
 /// ## Type Parameters
 ///
 /// * `P` - Provider marker type encoding the bound provider at compile time
-pub struct Agent<P: ProviderMarker> {
-    client: Arc<BoundClient<P>>,
-    model: ModelRef<P>,
+pub struct Agent {
+    client: Arc<BoundClient>,
+    model: ModelRef,
     instructions: Option<String>,
     tools: Vec<Tool>,
     max_steps: Option<u8>,
@@ -83,7 +83,7 @@ pub struct Agent<P: ProviderMarker> {
     max_output_tokens: Option<u32>,
     stop_sequences: Vec<String>,
     cancellation_token: Option<CancellationToken>,
-    prepare_step: Option<PrepareStepHook<P>>,
+    prepare_step: Option<PrepareStepHook>,
     on_start: Option<Hook<AgentStart>>,
     on_step_start: Option<Hook<AgentStepStart>>,
     on_tool_call_start: Option<Hook<AgentToolCallStart>>,
@@ -94,18 +94,18 @@ pub struct Agent<P: ProviderMarker> {
     tool_error_policy: ToolErrorPolicy,
 }
 
-impl<P: ProviderMarker> Agent<P> {
+impl Agent {
     /// Starts building an [`Agent`] from a provider-bound client and model.
     pub fn builder(
-        client: impl Into<Arc<BoundClient<P>>>,
-        model: impl IntoModelRef<P>,
-    ) -> AgentBuilder<P> {
-        AgentBuilder::new(client.into(), model.into_model_ref())
+        client: impl Into<Arc<BoundClient>>,
+        model: impl Into<ModelRef>,
+    ) -> AgentBuilder {
+        AgentBuilder::new(client.into(), model.into())
     }
 
     /// Returns the fully qualified model id (`<provider>/<model>`).
     pub fn model_id(&self) -> String {
-        self.model.id()
+        self.model.model().to_string()
     }
 
     /// Prepends instructions as a system message if configured and no system
@@ -212,9 +212,9 @@ impl<P: ProviderMarker> Agent<P> {
 }
 
 /// Builder for configuring an [`Agent`].
-pub struct AgentBuilder<P: ProviderMarker> {
-    client: Arc<BoundClient<P>>,
-    model: ModelRef<P>,
+pub struct AgentBuilder {
+    client: Arc<BoundClient>,
+    model: ModelRef,
     instructions: Option<String>,
     tools: Vec<Tool>,
     max_steps: Option<u8>,
@@ -223,7 +223,7 @@ pub struct AgentBuilder<P: ProviderMarker> {
     max_output_tokens: Option<u32>,
     stop_sequences: Vec<String>,
     cancellation_token: Option<CancellationToken>,
-    prepare_step: Option<PrepareStepHook<P>>,
+    prepare_step: Option<PrepareStepHook>,
     on_start: Option<Hook<AgentStart>>,
     on_step_start: Option<Hook<AgentStepStart>>,
     on_tool_call_start: Option<Hook<AgentToolCallStart>>,
@@ -234,8 +234,8 @@ pub struct AgentBuilder<P: ProviderMarker> {
     tool_error_policy: ToolErrorPolicy,
 }
 
-impl<P: ProviderMarker> AgentBuilder<P> {
-    fn new(client: Arc<BoundClient<P>>, model: ModelRef<P>) -> Self {
+impl AgentBuilder {
+    fn new(client: Arc<BoundClient>, model: ModelRef) -> Self {
         Self {
             client,
             model,
@@ -323,7 +323,7 @@ impl<P: ProviderMarker> AgentBuilder<P> {
     /// Registers a callback to mutate per-step inputs right before each model call.
     pub fn prepare_step<F>(mut self, callback: F) -> Self
     where
-        F: Fn(&AgentPrepareStep<P>) -> AgentPreparedStep<P> + Send + Sync + 'static,
+        F: Fn(&AgentPrepareStep) -> AgentPreparedStep + Send + Sync + 'static,
     {
         self.prepare_step = Some(Arc::new(callback));
         self
@@ -399,7 +399,7 @@ impl<P: ProviderMarker> AgentBuilder<P> {
     }
 
     /// Validates configuration and builds the [`Agent`].
-    pub fn build(self) -> Result<Agent<P>, crate::error::Error> {
+    pub fn build(self) -> Result<Agent, crate::error::Error> {
         validate_model_ref(&self.model)?;
         if let Some(max_steps) = self.max_steps {
             validate_max_steps(max_steps)?;
@@ -446,7 +446,7 @@ mod tests {
             .build()
             .expect("agent should build");
 
-        assert_eq!(agent.model_id(), "openai/gpt-4o-mini");
+        assert_eq!(agent.model_id(), "gpt-4o-mini");
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2,8 +2,8 @@
 //!
 //! This module provides the multi-step tool-using agent abstraction:
 //!
-//! - [`Agent<P>`]: Main agent runtime for tool loops
-//! - [`AgentBuilder<P>`]: Builder for configuring agent behavior
+//! - [`Agent`]: Main agent runtime for tool loops
+//! - [`AgentBuilder`]: Builder for configuring agent behavior
 //!
 //! ## Agent Architecture
 //!
@@ -68,10 +68,6 @@ use crate::types::{
 /// - **Early stopping**: `stop_when` predicate for custom termination conditions
 /// - **Cancellation**: Bind a `CancellationToken` at builder time to cancel running agents
 /// - **Error policies**: Configurable tool error handling (`ContinueAsToolResult` or `FailFast`)
-///
-/// ## Type Parameters
-///
-/// * `P` - Provider marker type encoding the bound provider at compile time
 pub struct Agent {
     client: Arc<BoundClient>,
     model: ModelRef,

--- a/src/client.rs
+++ b/src/client.rs
@@ -52,10 +52,9 @@ use crate::model_adapters::openai_compatible::{
 use crate::tool::{ToolExecError, ToolRegistry};
 use crate::types::{
     AgentFinish, AgentPrepareStep, AgentPreparedStep, AgentResponse, AgentStart, AgentStep,
-    AgentStepStart, AgentToolCallFinish, AgentToolCallStart, ContentPart,
-    GenerateTextRequest, GenerateTextResponse, Message,
-    RunTools, TextStream, ToolCall, ToolErrorPolicy, ToolResult, Usage,
-    validate_max_steps, validate_messages, validate_model_ref, validate_sampling,
+    AgentStepStart, AgentToolCallFinish, AgentToolCallStart, ContentPart, GenerateTextRequest,
+    GenerateTextResponse, Message, RunTools, TextStream, ToolCall, ToolErrorPolicy, ToolResult,
+    Usage, validate_max_steps, validate_messages, validate_model_ref, validate_sampling,
 };
 
 pub(crate) trait BuildProvider {
@@ -66,7 +65,10 @@ pub(crate) trait BuildProvider {
 impl BuildProvider for OpenAiAdapterSettings {
     fn validate(&self) -> Result<(), Error> {
         if self.api_key.trim().is_empty() {
-            return Err(Error::new(ErrorCode::AuthFailed, "api_key must not be empty"));
+            return Err(Error::new(
+                ErrorCode::AuthFailed,
+                "api_key must not be empty",
+            ));
         }
         Ok(())
     }
@@ -78,7 +80,10 @@ impl BuildProvider for OpenAiAdapterSettings {
 impl BuildProvider for AnthropicAdapterSettings {
     fn validate(&self) -> Result<(), Error> {
         if self.api_key.trim().is_empty() {
-            return Err(Error::new(ErrorCode::AuthFailed, "api_key must not be empty"));
+            return Err(Error::new(
+                ErrorCode::AuthFailed,
+                "api_key must not be empty",
+            ));
         }
         Ok(())
     }
@@ -90,7 +95,10 @@ impl BuildProvider for AnthropicAdapterSettings {
 impl BuildProvider for GoogleAdapterSettings {
     fn validate(&self) -> Result<(), Error> {
         if self.api_key.trim().is_empty() {
-            return Err(Error::new(ErrorCode::AuthFailed, "api_key must not be empty"));
+            return Err(Error::new(
+                ErrorCode::AuthFailed,
+                "api_key must not be empty",
+            ));
         }
         Ok(())
     }
@@ -102,7 +110,10 @@ impl BuildProvider for GoogleAdapterSettings {
 impl BuildProvider for OpenAiCompatibleAdapterSettings {
     fn validate(&self) -> Result<(), Error> {
         if self.base_url.trim().is_empty() {
-            return Err(Error::new(ErrorCode::InvalidRequest, "base_url must not be empty"));
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "base_url must not be empty",
+            ));
         }
         Ok(())
     }
@@ -134,7 +145,9 @@ impl LlmClient {
     }
 
     /// Creates an OpenAI-compatible client builder.
-    pub fn openai_compatible(base_url: impl Into<String>) -> ClientBuilder<OpenAiCompatibleAdapterSettings> {
+    pub fn openai_compatible(
+        base_url: impl Into<String>,
+    ) -> ClientBuilder<OpenAiCompatibleAdapterSettings> {
         ClientBuilder::new(OpenAiCompatibleAdapterSettings::new(base_url))
     }
 }
@@ -293,10 +306,7 @@ impl BoundClient {
     /// Runs a non-streaming generation request.
     ///
     /// The request is validated locally and retried on retryable failures.
-    pub async fn generate(
-        &self,
-        req: GenerateTextRequest,
-    ) -> Result<GenerateTextResponse, Error> {
+    pub async fn generate(&self, req: GenerateTextRequest) -> Result<GenerateTextResponse, Error> {
         validate_model_ref(&req.model)?;
         validate_messages(&req.messages)?;
         validate_sampling(req.temperature, req.top_p)?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -57,7 +57,8 @@ use crate::types::{
     Usage, validate_max_steps, validate_messages, validate_model_ref, validate_sampling,
 };
 
-pub(crate) trait BuildProvider {
+#[doc(hidden)]
+pub trait BuildProvider {
     fn validate(&self) -> Result<(), Error>;
     fn into_adapter(self, http: Arc<reqwest::Client>) -> Arc<dyn ModelAdapter>;
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,14 +3,13 @@
 //! This module provides the core client abstractions for making LLM requests:
 //!
 //! - [`LlmClient`]: Entry point for creating provider-specific clients
-//! - [`ClientBuilder<P>`]: Builder for configuring HTTP/runtime behavior
+//! - [`ClientBuilder`]: Builder for configuring HTTP/runtime behavior
 //! - [`BoundClient`]: Reusable client for generate/stream/agent operations
 //!
 //! ## Architecture
 //!
-//! The client architecture uses a type-state pattern where:
-//! 1. [`LlmClient`] constructors return a [`ClientBuilder<P>`] with provider type `P`
-//! 2. [`ClientBuilder<P>`] configures settings and HTTP behavior
+//! 1. [`LlmClient`] constructors return a [`ClientBuilder`] parameterised on the settings type
+//! 2. [`ClientBuilder`] configures settings and HTTP behavior
 //! 3. [`ClientBuilder::build()`] produces a [`BoundClient`]
 //! 4. [`BoundClient`] is used for all subsequent operations
 //!

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,15 +4,15 @@
 //!
 //! - [`LlmClient`]: Entry point for creating provider-specific clients
 //! - [`ClientBuilder<P>`]: Builder for configuring HTTP/runtime behavior
-//! - [`BoundClient<P>`]: Reusable client for generate/stream/agent operations
+//! - [`BoundClient`]: Reusable client for generate/stream/agent operations
 //!
 //! ## Architecture
 //!
 //! The client architecture uses a type-state pattern where:
 //! 1. [`LlmClient`] constructors return a [`ClientBuilder<P>`] with provider type `P`
 //! 2. [`ClientBuilder<P>`] configures settings and HTTP behavior
-//! 3. [`ClientBuilder<P>::build()`] produces a [`BoundClient<P>`]
-//! 4. [`BoundClient<P>`] is used for all subsequent operations
+//! 3. [`ClientBuilder::build()`] produces a [`BoundClient`]
+//! 4. [`BoundClient`] is used for all subsequent operations
 //!
 //! ## Example
 //!
@@ -36,7 +36,6 @@
 //! # }
 //! ```
 
-use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -54,129 +53,62 @@ use crate::model_adapters::openai_compatible::{
 use crate::tool::{ToolExecError, ToolRegistry};
 use crate::types::{
     AgentFinish, AgentPrepareStep, AgentPreparedStep, AgentResponse, AgentStart, AgentStep,
-    AgentStepStart, AgentToolCallFinish, AgentToolCallStart, Anthropic, ContentPart,
-    GenerateTextRequest, GenerateTextResponse, Google, Message, OpenAi, OpenAiCompatible,
-    ProviderMarker, RunTools, TextStream, ToolCall, ToolErrorPolicy, ToolResult, Usage,
+    AgentStepStart, AgentToolCallFinish, AgentToolCallStart, ContentPart,
+    GenerateTextRequest, GenerateTextResponse, Message,
+    RunTools, TextStream, ToolCall, ToolErrorPolicy, ToolResult, Usage,
     validate_max_steps, validate_messages, validate_model_ref, validate_sampling,
 };
 
-/// Binds a provider marker type to its adapter settings and adapter implementation.
-///
-/// This trait is mainly an internal extension seam used by [`ClientBuilder`].
-/// It associates each provider marker with its specific settings type and
-/// provides the conversion logic to create a runtime adapter.
-///
-/// ## Implementors
-///
-/// This trait is implemented for the four provider markers:
-/// - [`OpenAi`]
-/// - [`Anthropic`]
-/// - [`Google`]
-/// - [`OpenAiCompatible`]
-pub trait ProviderBinding: ProviderMarker {
-    /// Provider-specific client configuration payload.
-    ///
-    /// Each provider has different configuration options:
-    /// - OpenAI: `base_url`, `api_key`
-    /// - Anthropic: `base_url`, `api_key`, `api_version`
-    /// - Google: `base_url`, `api_key`
-    /// - OpenAI-compatible: `base_url`, optional `api_key`, custom headers/query params
-    type Settings;
-
-    /// Converts provider settings into a runtime adapter.
-    ///
-    /// This method consumes the settings and creates a boxed adapter trait object
-    /// that handles provider-specific request/response formatting.
-    fn into_adapter(
-        settings: Self::Settings,
-        http: Arc<reqwest::Client>,
-    ) -> Arc<dyn ModelAdapter<Self>>;
-
-    /// Validates provider settings (e.g. non-empty api_key / base_url).
-    fn validate_settings(settings: &Self::Settings) -> Result<(), Error>;
+pub(crate) trait BuildProvider {
+    fn validate(&self) -> Result<(), Error>;
+    fn into_adapter(self, http: Arc<reqwest::Client>) -> Arc<dyn ModelAdapter>;
 }
 
-impl ProviderBinding for OpenAi {
-    type Settings = OpenAiAdapterSettings;
-
-    fn into_adapter(
-        settings: Self::Settings,
-        http: Arc<reqwest::Client>,
-    ) -> Arc<dyn ModelAdapter<Self>> {
-        Arc::new(OpenAiAdapter::from_settings(settings, http))
-    }
-
-    fn validate_settings(settings: &Self::Settings) -> Result<(), Error> {
-        if settings.api_key.trim().is_empty() {
-            return Err(Error::new(
-                ErrorCode::AuthFailed,
-                "api_key must not be empty",
-            ));
+impl BuildProvider for OpenAiAdapterSettings {
+    fn validate(&self) -> Result<(), Error> {
+        if self.api_key.trim().is_empty() {
+            return Err(Error::new(ErrorCode::AuthFailed, "api_key must not be empty"));
         }
         Ok(())
     }
-}
-
-impl ProviderBinding for Anthropic {
-    type Settings = AnthropicAdapterSettings;
-
-    fn into_adapter(
-        settings: Self::Settings,
-        http: Arc<reqwest::Client>,
-    ) -> Arc<dyn ModelAdapter<Self>> {
-        Arc::new(AnthropicAdapter::from_settings(settings, http))
-    }
-
-    fn validate_settings(settings: &Self::Settings) -> Result<(), Error> {
-        if settings.api_key.trim().is_empty() {
-            return Err(Error::new(
-                ErrorCode::AuthFailed,
-                "api_key must not be empty",
-            ));
-        }
-        Ok(())
+    fn into_adapter(self, http: Arc<reqwest::Client>) -> Arc<dyn ModelAdapter> {
+        Arc::new(OpenAiAdapter::from_settings(self, http))
     }
 }
 
-impl ProviderBinding for Google {
-    type Settings = GoogleAdapterSettings;
-
-    fn into_adapter(
-        settings: Self::Settings,
-        http: Arc<reqwest::Client>,
-    ) -> Arc<dyn ModelAdapter<Self>> {
-        Arc::new(GoogleAdapter::from_settings(settings, http))
-    }
-
-    fn validate_settings(settings: &Self::Settings) -> Result<(), Error> {
-        if settings.api_key.trim().is_empty() {
-            return Err(Error::new(
-                ErrorCode::AuthFailed,
-                "api_key must not be empty",
-            ));
+impl BuildProvider for AnthropicAdapterSettings {
+    fn validate(&self) -> Result<(), Error> {
+        if self.api_key.trim().is_empty() {
+            return Err(Error::new(ErrorCode::AuthFailed, "api_key must not be empty"));
         }
         Ok(())
+    }
+    fn into_adapter(self, http: Arc<reqwest::Client>) -> Arc<dyn ModelAdapter> {
+        Arc::new(AnthropicAdapter::from_settings(self, http))
     }
 }
 
-impl ProviderBinding for OpenAiCompatible {
-    type Settings = OpenAiCompatibleAdapterSettings;
-
-    fn into_adapter(
-        settings: Self::Settings,
-        http: Arc<reqwest::Client>,
-    ) -> Arc<dyn ModelAdapter<Self>> {
-        Arc::new(OpenAiCompatibleAdapter::from_settings(settings, http))
-    }
-
-    fn validate_settings(settings: &Self::Settings) -> Result<(), Error> {
-        if settings.base_url.trim().is_empty() {
-            return Err(Error::new(
-                ErrorCode::InvalidRequest,
-                "base_url must not be empty",
-            ));
+impl BuildProvider for GoogleAdapterSettings {
+    fn validate(&self) -> Result<(), Error> {
+        if self.api_key.trim().is_empty() {
+            return Err(Error::new(ErrorCode::AuthFailed, "api_key must not be empty"));
         }
         Ok(())
+    }
+    fn into_adapter(self, http: Arc<reqwest::Client>) -> Arc<dyn ModelAdapter> {
+        Arc::new(GoogleAdapter::from_settings(self, http))
+    }
+}
+
+impl BuildProvider for OpenAiCompatibleAdapterSettings {
+    fn validate(&self) -> Result<(), Error> {
+        if self.base_url.trim().is_empty() {
+            return Err(Error::new(ErrorCode::InvalidRequest, "base_url must not be empty"));
+        }
+        Ok(())
+    }
+    fn into_adapter(self, http: Arc<reqwest::Client>) -> Arc<dyn ModelAdapter> {
+        Arc::new(OpenAiCompatibleAdapter::from_settings(self, http))
     }
 }
 
@@ -188,37 +120,37 @@ pub struct LlmClient;
 
 impl LlmClient {
     /// Creates an OpenAI client builder.
-    pub fn openai(api_key: impl Into<String>) -> ClientBuilder<OpenAi> {
+    pub fn openai(api_key: impl Into<String>) -> ClientBuilder<OpenAiAdapterSettings> {
         ClientBuilder::new(OpenAiAdapterSettings::new(api_key))
     }
 
     /// Creates an Anthropic client builder.
-    pub fn anthropic(api_key: impl Into<String>) -> ClientBuilder<Anthropic> {
+    pub fn anthropic(api_key: impl Into<String>) -> ClientBuilder<AnthropicAdapterSettings> {
         ClientBuilder::new(AnthropicAdapterSettings::new(api_key))
     }
 
     /// Creates a Google client builder.
-    pub fn google(api_key: impl Into<String>) -> ClientBuilder<Google> {
+    pub fn google(api_key: impl Into<String>) -> ClientBuilder<GoogleAdapterSettings> {
         ClientBuilder::new(GoogleAdapterSettings::new(api_key))
     }
 
     /// Creates an OpenAI-compatible client builder.
-    pub fn openai_compatible(base_url: impl Into<String>) -> ClientBuilder<OpenAiCompatible> {
+    pub fn openai_compatible(base_url: impl Into<String>) -> ClientBuilder<OpenAiCompatibleAdapterSettings> {
         ClientBuilder::new(OpenAiCompatibleAdapterSettings::new(base_url))
     }
 }
 
 /// Configures HTTP/runtime behavior before building a [`BoundClient`].
-pub struct ClientBuilder<P: ProviderBinding> {
+pub struct ClientBuilder<S> {
     timeout: Duration,
     max_retries: u8,
     default_max_steps: u8,
     user_agent: String,
-    settings: P::Settings,
+    settings: S,
 }
 
-impl<P: ProviderBinding> ClientBuilder<P> {
-    fn new(settings: P::Settings) -> Self {
+impl<S: BuildProvider> ClientBuilder<S> {
+    fn new(settings: S) -> Self {
         Self {
             timeout: Duration::from_secs(30),
             max_retries: 3,
@@ -253,9 +185,9 @@ impl<P: ProviderBinding> ClientBuilder<P> {
     }
 
     /// Builds a provider-bound client with validated settings.
-    pub fn build(self) -> Result<BoundClient<P>, Error> {
+    pub fn build(self) -> Result<BoundClient, Error> {
         validate_max_steps(self.default_max_steps)?;
-        P::validate_settings(&self.settings)?;
+        self.settings.validate()?;
         let http = Arc::new(
             reqwest::Client::builder()
                 .timeout(self.timeout)
@@ -267,13 +199,12 @@ impl<P: ProviderBinding> ClientBuilder<P> {
         Ok(BoundClient {
             max_retries: self.max_retries,
             default_max_steps: self.default_max_steps,
-            adapter: P::into_adapter(self.settings, http),
-            _marker: PhantomData,
+            adapter: self.settings.into_adapter(http),
         })
     }
 }
 
-impl ClientBuilder<OpenAi> {
+impl ClientBuilder<OpenAiAdapterSettings> {
     /// Overrides the OpenAI API base URL.
     pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
         self.settings.base_url = base_url.into();
@@ -281,7 +212,7 @@ impl ClientBuilder<OpenAi> {
     }
 }
 
-impl ClientBuilder<Anthropic> {
+impl ClientBuilder<AnthropicAdapterSettings> {
     /// Overrides the Anthropic API base URL.
     pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
         self.settings.base_url = base_url.into();
@@ -295,7 +226,7 @@ impl ClientBuilder<Anthropic> {
     }
 }
 
-impl ClientBuilder<Google> {
+impl ClientBuilder<GoogleAdapterSettings> {
     /// Overrides the Google Generative Language API base URL.
     pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
         self.settings.base_url = base_url.into();
@@ -303,7 +234,7 @@ impl ClientBuilder<Google> {
     }
 }
 
-impl ClientBuilder<OpenAiCompatible> {
+impl ClientBuilder<OpenAiCompatibleAdapterSettings> {
     /// Sets a bearer token for OpenAI-compatible requests.
     pub fn api_key(mut self, api_key: impl Into<String>) -> Self {
         self.settings.set_api_key(api_key);
@@ -353,20 +284,19 @@ impl ClientBuilder<OpenAiCompatible> {
 }
 
 /// Reusable provider-bound client used for `generate`, `stream`, and agent loops.
-pub struct BoundClient<P: ProviderMarker> {
+pub struct BoundClient {
     max_retries: u8,
     default_max_steps: u8,
-    adapter: Arc<dyn ModelAdapter<P>>,
-    _marker: PhantomData<P>,
+    adapter: Arc<dyn ModelAdapter>,
 }
 
-impl<P: ProviderMarker> BoundClient<P> {
+impl BoundClient {
     /// Runs a non-streaming generation request.
     ///
     /// The request is validated locally and retried on retryable failures.
     pub async fn generate(
         &self,
-        req: GenerateTextRequest<P>,
+        req: GenerateTextRequest,
     ) -> Result<GenerateTextResponse, Error> {
         validate_model_ref(&req.model)?;
         validate_messages(&req.messages)?;
@@ -378,7 +308,7 @@ impl<P: ProviderMarker> BoundClient<P> {
     /// Runs a streaming generation request.
     ///
     /// The request is validated locally and retried on retryable failures.
-    pub async fn stream(&self, req: GenerateTextRequest<P>) -> Result<TextStream, Error> {
+    pub async fn stream(&self, req: GenerateTextRequest) -> Result<TextStream, Error> {
         validate_model_ref(&req.model)?;
         validate_messages(&req.messages)?;
         validate_sampling(req.temperature, req.top_p)?;
@@ -386,7 +316,7 @@ impl<P: ProviderMarker> BoundClient<P> {
             .await
     }
 
-    pub(crate) async fn run_tools(&self, req: RunTools<P>) -> Result<AgentResponse, Error> {
+    pub(crate) async fn run_tools(&self, req: RunTools) -> Result<AgentResponse, Error> {
         let RunTools {
             model,
             messages,
@@ -419,7 +349,7 @@ impl<P: ProviderMarker> BoundClient<P> {
 
         if let Some(callback) = &on_start {
             callback(&AgentStart {
-                model_id: model.id(),
+                model_id: model.model().to_string(),
                 messages: messages.clone(),
                 tool_count: tools.len(),
                 max_steps: resolved_max_steps,

--- a/src/client.rs
+++ b/src/client.rs
@@ -699,41 +699,6 @@ async fn execute_tool_calls(
             ));
         };
 
-        if let Err(validation_err) = registered.validator.validate(&call.args_json) {
-            if policy == ToolErrorPolicy::FailFast {
-                return Err(Error::new(
-                    ErrorCode::InvalidToolArgs,
-                    format!(
-                        "tool args for `{}` failed schema validation: {}",
-                        call.tool_name, validation_err
-                    ),
-                ));
-            }
-            let tool_result = ToolResult {
-                call_id: call.call_id.clone(),
-                output_json: serde_json::json!({ "error": validation_err.to_string() }),
-                is_error: true,
-            };
-            if let Some(callback) = on_tool_call_start {
-                callback(&AgentToolCallStart {
-                    step,
-                    tool_call: call.clone(),
-                });
-            }
-            if let Some(callback) = on_tool_call_finish {
-                callback(&AgentToolCallFinish {
-                    step,
-                    tool_call: call.clone(),
-                    tool_result: tool_result.clone(),
-                    duration_ms: 0,
-                });
-            }
-            executions.push(ExecutedToolCall {
-                result: tool_result,
-            });
-            continue;
-        }
-
         if let Some(callback) = on_tool_call_start {
             callback(&AgentToolCallStart {
                 step,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,6 @@ pub use types::{
     AgentStepStart,
     AgentToolCallFinish,
     AgentToolCallStart,
-    // Provider markers
-    Anthropic,
     // Messages
     ContentPart,
     // Streaming
@@ -92,17 +90,12 @@ pub use types::{
     // Requests & responses
     GenerateTextRequest,
     GenerateTextResponse,
-    Google,
     ImagePart,
-    IntoModelRef,
     MediaData,
     Message,
     MessageRole,
     ModelRef,
-    OpenAi,
-    OpenAiCompatible,
     ProviderKind,
-    ProviderMarker,
     ReasoningPart,
     StreamEvent,
     TextDeltaStream,

--- a/src/model_adapters/anthropic/mod.rs
+++ b/src/model_adapters/anthropic/mod.rs
@@ -40,14 +40,12 @@ use std::sync::Arc;
 
 use async_stream::try_stream;
 use async_trait::async_trait;
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD;
 use futures_util::StreamExt;
 use reqwest::header::CONTENT_TYPE;
 use serde_json::{Map, Value, json};
 
 use crate::error::{Error, ErrorCode};
-use crate::model_adapters::{ModelAdapter, check_response_status, map_send_error};
+use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, map_send_error};
 use crate::stream::drain_sse_frames;
 use crate::types::{
     Anthropic, ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart,
@@ -585,7 +583,7 @@ fn anthropic_image_block(image: &ImagePart) -> Value {
             })
         }
         MediaData::Bytes(bytes) => {
-            let data = STANDARD.encode(bytes);
+            let data = base64_encode(bytes);
             let media_type = image.media_type.as_deref().unwrap_or("image/jpeg");
             json!({
                 "type": "image",

--- a/src/model_adapters/anthropic/mod.rs
+++ b/src/model_adapters/anthropic/mod.rs
@@ -48,7 +48,7 @@ use crate::error::{Error, ErrorCode};
 use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, map_send_error};
 use crate::stream::drain_sse_frames;
 use crate::types::{
-    Anthropic, ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart,
+    ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart,
     MediaData, Message, MessageRole, ReasoningPart, StreamEvent, TextStream, ToolCall, Usage,
 };
 
@@ -101,10 +101,10 @@ impl AnthropicAdapter {
 }
 
 #[async_trait]
-impl ModelAdapter<Anthropic> for AnthropicAdapter {
+impl ModelAdapter for AnthropicAdapter {
     async fn generate_text(
         &self,
-        req: &GenerateTextRequest<Anthropic>,
+        req: &GenerateTextRequest,
     ) -> Result<GenerateTextResponse, Error> {
         let payload = build_anthropic_payload(req, false);
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
@@ -134,7 +134,7 @@ impl ModelAdapter<Anthropic> for AnthropicAdapter {
         normalize_anthropic_response(body)
     }
 
-    async fn stream_text(&self, req: &GenerateTextRequest<Anthropic>) -> Result<TextStream, Error> {
+    async fn stream_text(&self, req: &GenerateTextRequest) -> Result<TextStream, Error> {
         let payload = build_anthropic_payload(req, true);
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
         let cancel_token = req.cancellation_token.clone();
@@ -396,7 +396,7 @@ impl PendingToolUse {
     }
 }
 
-fn build_anthropic_payload(req: &GenerateTextRequest<Anthropic>, stream: bool) -> Value {
+fn build_anthropic_payload(req: &GenerateTextRequest, stream: bool) -> Value {
     let mut payload = Map::new();
     payload.insert(
         "model".to_string(),

--- a/src/model_adapters/anthropic/mod.rs
+++ b/src/model_adapters/anthropic/mod.rs
@@ -48,8 +48,8 @@ use crate::error::{Error, ErrorCode};
 use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, map_send_error};
 use crate::stream::drain_sse_frames;
 use crate::types::{
-    ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart,
-    MediaData, Message, MessageRole, ReasoningPart, StreamEvent, TextStream, ToolCall, Usage,
+    ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart, MediaData,
+    Message, MessageRole, ReasoningPart, StreamEvent, TextStream, ToolCall, Usage,
 };
 
 /// Provider slug used in ids and error metadata.

--- a/src/model_adapters/google/mod.rs
+++ b/src/model_adapters/google/mod.rs
@@ -47,8 +47,8 @@ use crate::error::{Error, ErrorCode};
 use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, map_send_error};
 use crate::stream::drain_sse_frames;
 use crate::types::{
-    ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart,
-    MediaData, Message, MessageRole, ReasoningPart, StreamEvent, TextStream, ToolCall, Usage,
+    ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart, MediaData,
+    Message, MessageRole, ReasoningPart, StreamEvent, TextStream, ToolCall, Usage,
 };
 
 /// Provider slug used in ids and error metadata.

--- a/src/model_adapters/google/mod.rs
+++ b/src/model_adapters/google/mod.rs
@@ -39,14 +39,12 @@ use std::sync::Arc;
 
 use async_stream::try_stream;
 use async_trait::async_trait;
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD;
 use futures_util::StreamExt;
 use reqwest::header::CONTENT_TYPE;
 use serde_json::{Map, Value, json};
 
 use crate::error::{Error, ErrorCode};
-use crate::model_adapters::{ModelAdapter, check_response_status, map_send_error};
+use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, map_send_error};
 use crate::stream::drain_sse_frames;
 use crate::types::{
     ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, Google, ImagePart,
@@ -498,7 +496,7 @@ fn google_image_part(image: &ImagePart) -> Value {
         }
         MediaData::Bytes(bytes) => {
             let mt = image.media_type.as_deref().unwrap_or("image/jpeg");
-            json!({ "inlineData": { "mimeType": mt, "data": STANDARD.encode(bytes) } })
+            json!({ "inlineData": { "mimeType": mt, "data": base64_encode(bytes) } })
         }
     }
 }

--- a/src/model_adapters/google/mod.rs
+++ b/src/model_adapters/google/mod.rs
@@ -47,7 +47,7 @@ use crate::error::{Error, ErrorCode};
 use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, map_send_error};
 use crate::stream::drain_sse_frames;
 use crate::types::{
-    ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, Google, ImagePart,
+    ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart,
     MediaData, Message, MessageRole, ReasoningPart, StreamEvent, TextStream, ToolCall, Usage,
 };
 
@@ -109,10 +109,10 @@ impl GoogleAdapter {
 }
 
 #[async_trait]
-impl ModelAdapter<Google> for GoogleAdapter {
+impl ModelAdapter for GoogleAdapter {
     async fn generate_text(
         &self,
-        req: &GenerateTextRequest<Google>,
+        req: &GenerateTextRequest,
     ) -> Result<GenerateTextResponse, Error> {
         let payload = build_google_payload(req);
         let cancel_token = req.cancellation_token.clone();
@@ -140,7 +140,7 @@ impl ModelAdapter<Google> for GoogleAdapter {
         normalize_google_response(body)
     }
 
-    async fn stream_text(&self, req: &GenerateTextRequest<Google>) -> Result<TextStream, Error> {
+    async fn stream_text(&self, req: &GenerateTextRequest) -> Result<TextStream, Error> {
         let payload = build_google_payload(req);
         let cancel_token = req.cancellation_token.clone();
         let cancel_token_stream = cancel_token.clone();
@@ -289,7 +289,7 @@ impl ModelAdapter<Google> for GoogleAdapter {
     }
 }
 
-fn build_google_payload(req: &GenerateTextRequest<Google>) -> Value {
+fn build_google_payload(req: &GenerateTextRequest) -> Value {
     let (contents, system_instruction) = to_google_messages(&req.messages);
 
     let mut payload = Map::new();

--- a/src/model_adapters/mod.rs
+++ b/src/model_adapters/mod.rs
@@ -108,3 +108,19 @@ pub(crate) async fn check_response_status(
 pub(crate) fn map_send_error(provider_id: &str, err: reqwest::Error) -> Error {
     crate::error::transport_error(provider_id, err)
 }
+
+pub(crate) fn base64_encode(data: &[u8]) -> String {
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as usize;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as usize;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as usize;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(CHARS[(n >> 18) & 0x3f] as char);
+        out.push(CHARS[(n >> 12) & 0x3f] as char);
+        out.push(if chunk.len() > 1 { CHARS[(n >> 6) & 0x3f] as char } else { '=' });
+        out.push(if chunk.len() > 2 { CHARS[n & 0x3f] as char } else { '=' });
+    }
+    out
+}

--- a/src/model_adapters/mod.rs
+++ b/src/model_adapters/mod.rs
@@ -61,7 +61,8 @@ pub(crate) mod think_tag_parser;
 /// Provider adapter contract used by [`crate::BoundClient`].
 #[async_trait]
 pub trait ModelAdapter: Send + Sync {
-    async fn generate_text(&self, req: &GenerateTextRequest) -> Result<GenerateTextResponse, Error>;
+    async fn generate_text(&self, req: &GenerateTextRequest)
+    -> Result<GenerateTextResponse, Error>;
     async fn stream_text(&self, req: &GenerateTextRequest) -> Result<TextStream, Error>;
 }
 
@@ -110,8 +111,16 @@ pub(crate) fn base64_encode(data: &[u8]) -> String {
         let n = (b0 << 16) | (b1 << 8) | b2;
         out.push(CHARS[(n >> 18) & 0x3f] as char);
         out.push(CHARS[(n >> 12) & 0x3f] as char);
-        out.push(if chunk.len() > 1 { CHARS[(n >> 6) & 0x3f] as char } else { '=' });
-        out.push(if chunk.len() > 2 { CHARS[n & 0x3f] as char } else { '=' });
+        out.push(if chunk.len() > 1 {
+            CHARS[(n >> 6) & 0x3f] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            CHARS[n & 0x3f] as char
+        } else {
+            '='
+        });
     }
     out
 }

--- a/src/model_adapters/mod.rs
+++ b/src/model_adapters/mod.rs
@@ -103,7 +103,7 @@ pub(crate) fn map_send_error(provider_id: &str, err: reqwest::Error) -> Error {
 
 pub(crate) fn base64_encode(data: &[u8]) -> String {
     const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
     for chunk in data.chunks(3) {
         let b0 = chunk[0] as usize;
         let b1 = chunk.get(1).copied().unwrap_or(0) as usize;

--- a/src/model_adapters/mod.rs
+++ b/src/model_adapters/mod.rs
@@ -46,7 +46,7 @@ use async_trait::async_trait;
 use reqwest::Response;
 
 use crate::error::Error;
-use crate::types::{GenerateTextRequest, GenerateTextResponse, ProviderMarker, TextStream};
+use crate::types::{GenerateTextRequest, GenerateTextResponse, TextStream};
 
 /// Anthropic provider adapter implementation.
 pub mod anthropic;
@@ -59,19 +59,10 @@ pub mod openai_compatible;
 pub(crate) mod think_tag_parser;
 
 /// Provider adapter contract used by [`crate::BoundClient`].
-///
-/// End users typically do not implement this trait directly unless integrating
-/// a custom in-tree provider adapter.
 #[async_trait]
-pub trait ModelAdapter<P: ProviderMarker>: Send + Sync {
-    /// Executes a non-streaming text generation call.
-    async fn generate_text(
-        &self,
-        req: &GenerateTextRequest<P>,
-    ) -> Result<GenerateTextResponse, Error>;
-
-    /// Executes a streaming text generation call.
-    async fn stream_text(&self, req: &GenerateTextRequest<P>) -> Result<TextStream, Error>;
+pub trait ModelAdapter: Send + Sync {
+    async fn generate_text(&self, req: &GenerateTextRequest) -> Result<GenerateTextResponse, Error>;
+    async fn stream_text(&self, req: &GenerateTextRequest) -> Result<TextStream, Error>;
 }
 
 pub(crate) async fn check_response_status(

--- a/src/model_adapters/openai/mod.rs
+++ b/src/model_adapters/openai/mod.rs
@@ -48,7 +48,7 @@ use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, 
 use crate::stream::drain_sse_frames;
 use crate::types::{
     ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart, MediaData,
-    Message, MessageRole, OpenAi, ReasoningPart, StreamEvent, TextStream, ToolCall, Usage,
+    Message, MessageRole, ReasoningPart, StreamEvent, TextStream, ToolCall, Usage,
 };
 
 /// Provider slug used in ids and error metadata.
@@ -96,10 +96,10 @@ impl OpenAiAdapter {
 }
 
 #[async_trait]
-impl ModelAdapter<OpenAi> for OpenAiAdapter {
+impl ModelAdapter for OpenAiAdapter {
     async fn generate_text(
         &self,
-        req: &GenerateTextRequest<OpenAi>,
+        req: &GenerateTextRequest,
     ) -> Result<GenerateTextResponse, Error> {
         let payload = build_openai_payload(req, false);
         let url = format!(
@@ -131,7 +131,7 @@ impl ModelAdapter<OpenAi> for OpenAiAdapter {
         normalize_openai_response(body)
     }
 
-    async fn stream_text(&self, req: &GenerateTextRequest<OpenAi>) -> Result<TextStream, Error> {
+    async fn stream_text(&self, req: &GenerateTextRequest) -> Result<TextStream, Error> {
         let payload = build_openai_payload(req, true);
         let url = format!(
             "{}/v1/chat/completions",
@@ -369,7 +369,7 @@ impl PartialToolCall {
     }
 }
 
-fn build_openai_payload(req: &GenerateTextRequest<OpenAi>, stream: bool) -> Value {
+fn build_openai_payload(req: &GenerateTextRequest, stream: bool) -> Value {
     let mut payload = Map::new();
     payload.insert(
         "model".to_string(),

--- a/src/model_adapters/openai/mod.rs
+++ b/src/model_adapters/openai/mod.rs
@@ -39,14 +39,12 @@ use std::sync::Arc;
 
 use async_stream::try_stream;
 use async_trait::async_trait;
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD;
 use futures_util::StreamExt;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
 use serde_json::{Map, Value, json};
 
 use crate::error::{Error, ErrorCode};
-use crate::model_adapters::{ModelAdapter, check_response_status, map_send_error};
+use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, map_send_error};
 use crate::stream::drain_sse_frames;
 use crate::types::{
     ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart, MediaData,
@@ -554,7 +552,7 @@ fn openai_image_content_part(image: &ImagePart) -> Value {
         }
         MediaData::Bytes(bytes) => {
             let mt = image.media_type.as_deref().unwrap_or("image/jpeg");
-            format!("data:{};base64,{}", mt, STANDARD.encode(bytes))
+            format!("data:{};base64,{}", mt, base64_encode(bytes))
         }
     };
     json!({ "type": "image_url", "image_url": { "url": url } })

--- a/src/model_adapters/openai_compatible/mod.rs
+++ b/src/model_adapters/openai_compatible/mod.rs
@@ -47,8 +47,6 @@ use std::sync::Arc;
 
 use async_stream::try_stream;
 use async_trait::async_trait;
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD;
 use futures_util::StreamExt;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
 use serde_json::{Map, Value, json};
@@ -57,7 +55,7 @@ use crate::error::{Error, ErrorCode};
 use crate::model_adapters::think_tag_parser::{
     ThinkTagSegment, ThinkTagStreamParser, split_think_tags,
 };
-use crate::model_adapters::{ModelAdapter, check_response_status, map_send_error};
+use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, map_send_error};
 use crate::stream::drain_sse_frames;
 use crate::types::{
     ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart, MediaData,
@@ -203,7 +201,7 @@ impl OpenAiCompatibleAdapter {
 
     fn endpoint_url(&self) -> Result<String, Error> {
         let path = canonicalize_path(&self.chat_completions_path);
-        let mut url = url::Url::parse(self.base_url.trim()).map_err(|e| {
+        let mut url = reqwest::Url::parse(self.base_url.trim()).map_err(|e| {
             Error::new(
                 ErrorCode::InvalidRequest,
                 format!("invalid openai-compatible base url: {}", e),
@@ -821,7 +819,7 @@ fn openai_image_content_part(image: &ImagePart) -> Value {
         }
         MediaData::Bytes(bytes) => {
             let mt = image.media_type.as_deref().unwrap_or("image/jpeg");
-            format!("data:{};base64,{}", mt, STANDARD.encode(bytes))
+            format!("data:{};base64,{}", mt, base64_encode(bytes))
         }
     };
     json!({ "type": "image_url", "image_url": { "url": url } })

--- a/src/model_adapters/openai_compatible/mod.rs
+++ b/src/model_adapters/openai_compatible/mod.rs
@@ -59,7 +59,7 @@ use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, 
 use crate::stream::drain_sse_frames;
 use crate::types::{
     ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart, MediaData,
-    Message, MessageRole, OpenAiCompatible, ReasoningPart, StreamEvent, TextStream, ToolCall,
+    Message, MessageRole, ReasoningPart, StreamEvent, TextStream, ToolCall,
     Usage,
 };
 
@@ -315,10 +315,10 @@ fn map_think_segments_to_stream_events(
 }
 
 #[async_trait]
-impl ModelAdapter<OpenAiCompatible> for OpenAiCompatibleAdapter {
+impl ModelAdapter for OpenAiCompatibleAdapter {
     async fn generate_text(
         &self,
-        req: &GenerateTextRequest<OpenAiCompatible>,
+        req: &GenerateTextRequest,
     ) -> Result<GenerateTextResponse, Error> {
         let payload = build_openai_payload(req, false);
         let url = self.endpoint_url()?;
@@ -350,7 +350,7 @@ impl ModelAdapter<OpenAiCompatible> for OpenAiCompatibleAdapter {
 
     async fn stream_text(
         &self,
-        req: &GenerateTextRequest<OpenAiCompatible>,
+        req: &GenerateTextRequest,
     ) -> Result<TextStream, Error> {
         let payload = build_openai_payload(req, true);
         let url = self.endpoint_url()?;
@@ -636,7 +636,7 @@ impl PartialToolCall {
     }
 }
 
-fn build_openai_payload(req: &GenerateTextRequest<OpenAiCompatible>, stream: bool) -> Value {
+fn build_openai_payload(req: &GenerateTextRequest, stream: bool) -> Value {
     let mut payload = Map::new();
     payload.insert(
         "model".to_string(),

--- a/src/model_adapters/openai_compatible/mod.rs
+++ b/src/model_adapters/openai_compatible/mod.rs
@@ -59,8 +59,7 @@ use crate::model_adapters::{ModelAdapter, base64_encode, check_response_status, 
 use crate::stream::drain_sse_frames;
 use crate::types::{
     ContentPart, FinishReason, GenerateTextRequest, GenerateTextResponse, ImagePart, MediaData,
-    Message, MessageRole, ReasoningPart, StreamEvent, TextStream, ToolCall,
-    Usage,
+    Message, MessageRole, ReasoningPart, StreamEvent, TextStream, ToolCall, Usage,
 };
 
 /// Provider slug used in ids and error metadata.
@@ -348,10 +347,7 @@ impl ModelAdapter for OpenAiCompatibleAdapter {
         )
     }
 
-    async fn stream_text(
-        &self,
-        req: &GenerateTextRequest,
-    ) -> Result<TextStream, Error> {
+    async fn stream_text(&self, req: &GenerateTextRequest) -> Result<TextStream, Error> {
         let payload = build_openai_payload(req, true);
         let url = self.endpoint_url()?;
         let cancel_token = req.cancellation_token.clone();

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -39,8 +39,6 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use jsonschema::{Validator, validator_for};
-use regex::Regex;
 use schemars::{JsonSchema, schema_for};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -232,7 +230,6 @@ where
 
 pub(crate) struct RegisteredTool {
     pub tool: Tool,
-    pub validator: Validator,
 }
 
 /// Validated registry keyed by tool name.
@@ -244,12 +241,12 @@ impl ToolRegistry {
     /// Builds a registry and validates names and JSON Schemas.
     pub(crate) fn from_tools(tools: Vec<Tool>) -> Result<Self, Error> {
         let mut entries = HashMap::new();
-        let name_re = Regex::new(r"^[a-zA-Z0-9_-]{1,64}$")
-            .expect("tool name regex must be valid at compile time");
-
         for tool in tools {
             let name = tool.descriptor.name.clone();
-            if !name_re.is_match(&name) {
+            if name.is_empty()
+                || name.len() > 64
+                || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            {
                 return Err(Error::new(
                     ErrorCode::InvalidRequest,
                     format!("invalid tool name `{}`", name),
@@ -262,14 +259,7 @@ impl ToolRegistry {
                 ));
             }
 
-            let validator = validator_for(&tool.descriptor.input_schema).map_err(|e| {
-                Error::new(
-                    ErrorCode::InvalidRequest,
-                    format!("invalid JSON schema for tool `{}`: {}", name, e),
-                )
-            })?;
-
-            entries.insert(name, RegisteredTool { tool, validator });
+            entries.insert(name, RegisteredTool { tool });
         }
 
         Ok(Self { entries })
@@ -323,14 +313,6 @@ mod tests {
         let tools = vec![make_tool("echo"), make_tool("echo")];
         let result = ToolRegistry::from_tools(tools);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn compiles_and_validates_schema() {
-        let registry = ToolRegistry::from_tools(vec![make_tool("echo")]).unwrap();
-        let entry = registry.resolve("echo").unwrap();
-        assert!(entry.validator.validate(&json!({"x": 1})).is_ok());
-        assert!(entry.validator.validate(&json!({"y": 1})).is_err());
     }
 
     #[tokio::test]
@@ -394,20 +376,6 @@ mod tests {
         let name = "a".repeat(65);
         let tools = vec![make_tool(&name)];
         let result = ToolRegistry::from_tools(tools);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn registry_rejects_invalid_json_schema() {
-        let tool = Tool {
-            descriptor: ToolDescriptor {
-                name: "bad".to_string(),
-                description: String::new(),
-                input_schema: json!({"type": "invalid_type"}),
-            },
-            executor: Arc::new(EchoTool),
-        };
-        let result = ToolRegistry::from_tools(vec![tool]);
         assert!(result.is_err());
     }
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -245,7 +245,9 @@ impl ToolRegistry {
             let name = tool.descriptor.name.clone();
             if name.is_empty()
                 || name.len() > 64
-                || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+                || !name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
             {
                 return Err(Error::new(
                     ErrorCode::InvalidRequest,

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,7 +67,9 @@ pub struct ModelRef {
 impl ModelRef {
     /// Creates a model reference from a model id string.
     pub fn new(model: impl Into<String>) -> Self {
-        Self { model: model.into() }
+        Self {
+            model: model.into(),
+        }
     }
 
     /// Returns the model id string.
@@ -83,11 +85,15 @@ impl std::fmt::Display for ModelRef {
 }
 
 impl From<&str> for ModelRef {
-    fn from(s: &str) -> Self { ModelRef::new(s) }
+    fn from(s: &str) -> Self {
+        ModelRef::new(s)
+    }
 }
 
 impl From<String> for ModelRef {
-    fn from(s: String) -> Self { ModelRef::new(s) }
+    fn from(s: String) -> Self {
+        ModelRef::new(s)
+    }
 }
 
 /// Chat message role used across providers.
@@ -785,8 +791,7 @@ pub struct AgentPreparedStep {
 // ─────────── Callback type aliases ──────────────────────────────────────────
 
 pub(crate) type Hook<T> = Arc<dyn Fn(&T) + Send + Sync>;
-pub(crate) type PrepareStepHook =
-    Arc<dyn Fn(&AgentPrepareStep) -> AgentPreparedStep + Send + Sync>;
+pub(crate) type PrepareStepHook = Arc<dyn Fn(&AgentPrepareStep) -> AgentPreparedStep + Send + Sync>;
 pub(crate) type StopPredicate = Arc<dyn Fn(&AgentStep) -> bool + Send + Sync>;
 
 /// Normalized non-streaming generation response.
@@ -1700,8 +1705,7 @@ mod tests {
 
     #[test]
     fn builds_request_from_prompt() {
-        let request =
-            GenerateTextRequest::from_user_prompt(ModelRef::new("gpt-4o-mini"), "hello");
+        let request = GenerateTextRequest::from_user_prompt(ModelRef::new("gpt-4o-mini"), "hello");
         assert_eq!(request.messages.len(), 1);
         assert_eq!(request.model.model(), "gpt-4o-mini");
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,14 +2,12 @@
 //!
 //! This module defines the core data structures used throughout the Aquaregia SDK:
 //!
-//! - **Provider Markers**: Type-level markers for provider-specific typing (`OpenAi`, `Anthropic`, `Google`, `OpenAiCompatible`)
 //! - **Messages**: Provider-agnostic chat message types with support for text, images, reasoning, and tool content
 //! - **Requests/Responses**: Structured generation request and response types
 //! - **Streaming**: Event types emitted during streaming generation
 //! - **Agent Types**: Event types and plan structures for multi-step agent loops
 //! - **Usage**: Token usage counters with cache and reasoning token support
 
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -51,155 +49,45 @@ impl ProviderKind {
     }
 }
 
-/// Type marker for provider-specific request/response typing.
-///
-/// This trait is used to encode provider information at the type level, enabling
-/// compile-time type safety when working with provider-specific models and requests.
-/// The marker types (`OpenAi`, `Anthropic`, `Google`, `OpenAiCompatible`) implement this trait.
-pub trait ProviderMarker: Clone + Copy + Send + Sync + 'static {
-    /// Provider family represented by this marker type.
-    const KIND: ProviderKind;
-}
-
-/// OpenAI provider marker.
-///
-/// This marker type is used to create type-safe references to OpenAI models
-/// and requests. It ensures that OpenAI-specific settings and model names
-/// are used consistently throughout the SDK.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct OpenAi;
-
-impl ProviderMarker for OpenAi {
-    const KIND: ProviderKind = ProviderKind::OpenAi;
-}
-
-/// Anthropic provider marker.
-///
-/// This marker type is used to create type-safe references to Anthropic models
-/// and requests. It ensures that Anthropic-specific settings and model names
-/// are used consistently throughout the SDK.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct Anthropic;
-
-impl ProviderMarker for Anthropic {
-    const KIND: ProviderKind = ProviderKind::Anthropic;
-}
-
-/// Google provider marker.
-///
-/// This marker type is used to create type-safe references to Google Generative AI models
-/// and requests. It ensures that Google-specific settings and model names
-/// are used consistently throughout the SDK.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct Google;
-
-impl ProviderMarker for Google {
-    const KIND: ProviderKind = ProviderKind::Google;
-}
-
-/// OpenAI-compatible provider marker.
-///
-/// This marker type is used to create type-safe references to OpenAI-compatible
-/// endpoints (e.g., DeepSeek, local LLM servers). It ensures that compatible
-/// endpoint settings and model names are used consistently throughout the SDK.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct OpenAiCompatible;
-
-impl ProviderMarker for OpenAiCompatible {
-    const KIND: ProviderKind = ProviderKind::OpenAiCompatible;
-}
-
-/// Strongly-typed model reference carrying provider information at compile time.
-///
-/// This struct encapsulates a model identifier along with its provider type,
-/// providing type safety and convenience methods for working with models.
-/// The generic parameter `P` encodes the provider at the type level.
-///
-/// # Type Parameters
-///
-/// * `P` - Provider marker type (`OpenAi`, `Anthropic`, `Google`, or `OpenAiCompatible`)
+/// Model reference: a provider-local model identifier string.
 ///
 /// # Example
 ///
 /// ```
-/// use aquaregia::{ModelRef, OpenAi};
+/// use aquaregia::ModelRef;
 ///
-/// let model = ModelRef::<OpenAi>::new("gpt-4o");
-/// assert_eq!(model.id(), "openai/gpt-4o");
+/// let model = ModelRef::new("gpt-4o");
 /// assert_eq!(model.model(), "gpt-4o");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ModelRef<P: ProviderMarker> {
-    /// Provider-local model identifier.
+pub struct ModelRef {
     model: String,
-    #[serde(skip)]
-    /// Phantom data encoding the provider type at compile time.
-    _marker: PhantomData<P>,
 }
 
-impl<P: ProviderMarker> ModelRef<P> {
-    /// Creates a model reference from a provider-local model id.
-    ///
-    /// # Arguments
-    ///
-    /// * `model` - The provider-local model identifier (e.g., `"gpt-4o"`, `"claude-sonnet-4-5"`)
+impl ModelRef {
+    /// Creates a model reference from a model id string.
     pub fn new(model: impl Into<String>) -> Self {
-        let model = model.into();
-        Self {
-            model,
-            _marker: PhantomData,
-        }
+        Self { model: model.into() }
     }
 
-    /// Returns a fully-qualified model id (`<provider>/<model>`).
-    ///
-    /// This method returns the complete model identifier including the provider prefix,
-    /// suitable for logging, display, or configuration purposes.
-    pub fn id(&self) -> String {
-        format!("{}/{}", P::KIND.as_slug(), self.model)
-    }
-
-    /// Returns the provider-local model id.
-    ///
-    /// This method returns just the model identifier without the provider prefix,
-    /// as used in API requests to the specific provider.
+    /// Returns the model id string.
     pub fn model(&self) -> &str {
         &self.model
     }
 }
 
-impl<P: ProviderMarker> std::fmt::Display for ModelRef<P> {
+impl std::fmt::Display for ModelRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.id())
+        write!(f, "{}", self.model)
     }
 }
 
-/// Converts values into a typed [`ModelRef`].
-///
-/// This trait provides ergonomic conversion into [`ModelRef`] types,
-/// allowing string literals and `String` values to be used directly
-/// in APIs that expect model references.
-pub trait IntoModelRef<P: ProviderMarker> {
-    /// Performs the conversion.
-    fn into_model_ref(self) -> ModelRef<P>;
+impl From<&str> for ModelRef {
+    fn from(s: &str) -> Self { ModelRef::new(s) }
 }
 
-impl<P: ProviderMarker> IntoModelRef<P> for ModelRef<P> {
-    fn into_model_ref(self) -> ModelRef<P> {
-        self
-    }
-}
-
-impl<P: ProviderMarker> IntoModelRef<P> for &str {
-    fn into_model_ref(self) -> ModelRef<P> {
-        ModelRef::new(self)
-    }
-}
-
-impl<P: ProviderMarker> IntoModelRef<P> for String {
-    fn into_model_ref(self) -> ModelRef<P> {
-        ModelRef::new(self)
-    }
+impl From<String> for ModelRef {
+    fn from(s: String) -> Self { ModelRef::new(s) }
 }
 
 /// Chat message role used across providers.
@@ -457,10 +345,10 @@ pub struct ToolResult {
     pub is_error: bool,
 }
 
-/// Provider-typed request for generation/streaming calls.
+/// Request for generation/streaming calls.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GenerateTextRequest<P: ProviderMarker> {
-    pub(crate) model: ModelRef<P>,
+pub struct GenerateTextRequest {
+    pub(crate) model: ModelRef,
     pub(crate) messages: Vec<Message>,
     pub(crate) temperature: Option<f32>,
     pub(crate) top_p: Option<f32>,
@@ -471,11 +359,11 @@ pub struct GenerateTextRequest<P: ProviderMarker> {
     pub(crate) cancellation_token: Option<tokio_util::sync::CancellationToken>,
 }
 
-impl<P: ProviderMarker> GenerateTextRequest<P> {
+impl GenerateTextRequest {
     /// Builds a one-message request from a user prompt.
-    pub fn from_user_prompt(model: impl IntoModelRef<P>, prompt: impl Into<String>) -> Self {
+    pub fn from_user_prompt(model: impl Into<ModelRef>, prompt: impl Into<String>) -> Self {
         Self {
-            model: model.into_model_ref(),
+            model: model.into(),
             messages: vec![Message::user_text(prompt)],
             temperature: None,
             top_p: None,
@@ -487,10 +375,10 @@ impl<P: ProviderMarker> GenerateTextRequest<P> {
     }
 
     /// Starts a request builder.
-    pub fn builder(model: impl IntoModelRef<P>) -> GenerateTextRequestBuilder<P> {
+    pub fn builder(model: impl Into<ModelRef>) -> GenerateTextRequestBuilder {
         GenerateTextRequestBuilder {
             request: Self {
-                model: model.into_model_ref(),
+                model: model.into(),
                 messages: Vec::new(),
                 temperature: None,
                 top_p: None,
@@ -504,11 +392,11 @@ impl<P: ProviderMarker> GenerateTextRequest<P> {
 }
 
 /// Builder for [`GenerateTextRequest`].
-pub struct GenerateTextRequestBuilder<P: ProviderMarker> {
-    request: GenerateTextRequest<P>,
+pub struct GenerateTextRequestBuilder {
+    request: GenerateTextRequest,
 }
 
-impl<P: ProviderMarker> GenerateTextRequestBuilder<P> {
+impl GenerateTextRequestBuilder {
     /// Appends one message.
     pub fn message(mut self, message: Message) -> Self {
         self.request.messages.push(message);
@@ -568,7 +456,7 @@ impl<P: ProviderMarker> GenerateTextRequestBuilder<P> {
     }
 
     /// Validates and finalizes the request.
-    pub fn build(self) -> Result<GenerateTextRequest<P>, Error> {
+    pub fn build(self) -> Result<GenerateTextRequest, Error> {
         validate_model_ref(&self.request.model)?;
         validate_messages(&self.request.messages)?;
         validate_sampling(self.request.temperature, self.request.top_p)?;
@@ -587,8 +475,8 @@ pub enum ToolErrorPolicy {
 }
 
 #[derive(Clone)]
-pub(crate) struct RunTools<P: ProviderMarker> {
-    pub(crate) model: ModelRef<P>,
+pub(crate) struct RunTools {
+    pub(crate) model: ModelRef,
     pub(crate) messages: Vec<Message>,
     pub(crate) tools: Vec<Tool>,
     pub(crate) max_steps: Option<u8>,
@@ -596,7 +484,7 @@ pub(crate) struct RunTools<P: ProviderMarker> {
     pub(crate) top_p: Option<f32>,
     pub(crate) max_output_tokens: Option<u32>,
     pub(crate) stop_sequences: Vec<String>,
-    pub(crate) prepare_step: Option<PrepareStepHook<P>>,
+    pub(crate) prepare_step: Option<PrepareStepHook>,
     pub(crate) on_start: Option<Hook<AgentStart>>,
     pub(crate) on_step_start: Option<Hook<AgentStepStart>>,
     pub(crate) on_tool_call_start: Option<Hook<AgentToolCallStart>>,
@@ -609,10 +497,10 @@ pub(crate) struct RunTools<P: ProviderMarker> {
     pub(crate) cancellation_token: Option<tokio_util::sync::CancellationToken>,
 }
 
-impl<P: ProviderMarker> RunTools<P> {
-    pub(crate) fn new(model: impl IntoModelRef<P>) -> Self {
+impl RunTools {
+    pub(crate) fn new(model: impl Into<ModelRef>) -> Self {
         Self {
-            model: model.into_model_ref(),
+            model: model.into(),
             messages: Vec::new(),
             tools: Vec::new(),
             max_steps: None,
@@ -679,7 +567,7 @@ impl<P: ProviderMarker> RunTools<P> {
 
     pub(crate) fn prepare_step<F>(mut self, callback: F) -> Self
     where
-        F: Fn(&AgentPrepareStep<P>) -> AgentPreparedStep<P> + Send + Sync + 'static,
+        F: Fn(&AgentPrepareStep) -> AgentPreparedStep + Send + Sync + 'static,
     {
         self.prepare_step = Some(Arc::new(callback));
         self
@@ -858,11 +746,11 @@ pub struct AgentFinish {
 
 /// Per-step mutable input passed to `prepare_step`.
 #[derive(Debug, Clone)]
-pub struct AgentPrepareStep<P: ProviderMarker> {
+pub struct AgentPrepareStep {
     /// 1-based step index to be executed.
     pub step: u8,
     /// Model selected for this step.
-    pub model: ModelRef<P>,
+    pub model: ModelRef,
     /// Messages that will be sent unless changed.
     pub messages: Vec<Message>,
     /// Tools currently available for this step.
@@ -879,9 +767,9 @@ pub struct AgentPrepareStep<P: ProviderMarker> {
 
 /// Finalized step input returned by `prepare_step`.
 #[derive(Debug, Clone)]
-pub struct AgentPreparedStep<P: ProviderMarker> {
+pub struct AgentPreparedStep {
     /// Model selected for this step.
-    pub model: ModelRef<P>,
+    pub model: ModelRef,
     /// Messages to send for this step.
     pub messages: Vec<Message>,
     /// Tools available for this step.
@@ -897,8 +785,8 @@ pub struct AgentPreparedStep<P: ProviderMarker> {
 // ─────────── Callback type aliases ──────────────────────────────────────────
 
 pub(crate) type Hook<T> = Arc<dyn Fn(&T) + Send + Sync>;
-pub(crate) type PrepareStepHook<P> =
-    Arc<dyn Fn(&AgentPrepareStep<P>) -> AgentPreparedStep<P> + Send + Sync>;
+pub(crate) type PrepareStepHook =
+    Arc<dyn Fn(&AgentPrepareStep) -> AgentPreparedStep + Send + Sync>;
 pub(crate) type StopPredicate = Arc<dyn Fn(&AgentStep) -> bool + Send + Sync>;
 
 /// Normalized non-streaming generation response.
@@ -1200,9 +1088,9 @@ fn validate_message_parts(role: MessageRole, parts: &[ContentPart]) -> Result<()
     Ok(())
 }
 
-impl<P: ProviderMarker> AgentPrepareStep<P> {
+impl AgentPrepareStep {
     /// Converts this event payload into a mutable prepared-step value.
-    pub fn to_prepared(&self) -> AgentPreparedStep<P> {
+    pub fn to_prepared(&self) -> AgentPreparedStep {
         AgentPreparedStep {
             model: self.model.clone(),
             messages: self.messages.clone(),
@@ -1229,7 +1117,7 @@ pub(crate) fn validate_messages(messages: &[Message]) -> Result<(), Error> {
     Ok(())
 }
 
-pub(crate) fn validate_model_ref<P: ProviderMarker>(model: &ModelRef<P>) -> Result<(), Error> {
+pub(crate) fn validate_model_ref(model: &ModelRef) -> Result<(), Error> {
     if model.model().trim().is_empty() {
         return Err(Error::new(
             ErrorCode::InvalidRequest,
@@ -1273,17 +1161,17 @@ pub(crate) fn validate_max_steps(max_steps: u8) -> Result<(), Error> {
 mod tests {
     use super::*;
 
-    // ─── ModelRef / IntoModelRef ──────────────────────────────────────────
+    // ─── ModelRef ────────────────────────────────────────────────────────
 
     #[test]
     fn builds_openai_model() {
-        let model = ModelRef::<OpenAi>::new("gpt-4o-mini");
+        let model = ModelRef::new("gpt-4o-mini");
         assert_eq!(model.model(), "gpt-4o-mini");
     }
 
     #[test]
     fn rejects_empty_model_name() {
-        let model = ModelRef::<OpenAi>::new("  ");
+        let model = ModelRef::new("  ");
         let err = validate_model_ref(&model).expect_err("empty model should fail");
         assert!(
             err.message.contains("cannot be empty"),
@@ -1294,36 +1182,35 @@ mod tests {
 
     #[test]
     fn model_ref_display_matches_model_id() {
-        let model = ModelRef::<OpenAi>::new("gpt-4o-mini");
-        assert_eq!(model.to_string(), "openai/gpt-4o-mini");
+        let model = ModelRef::new("gpt-4o-mini");
+        assert_eq!(model.to_string(), "gpt-4o-mini");
     }
 
     #[test]
     fn model_ref_serialization_roundtrip() {
-        let model = ModelRef::<OpenAi>::new("gpt-4o");
+        let model = ModelRef::new("gpt-4o");
         let json = serde_json::to_string(&model).unwrap();
-        let deserialized: ModelRef<OpenAi> = serde_json::from_str(&json).unwrap();
+        let deserialized: ModelRef = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.model(), "gpt-4o");
-        assert_eq!(deserialized.id(), "openai/gpt-4o");
     }
 
     #[test]
     fn into_model_ref_from_string() {
-        let model: ModelRef<OpenAi> = "gpt-4o".into_model_ref();
+        let model: ModelRef = "gpt-4o".into();
         assert_eq!(model.model(), "gpt-4o");
     }
 
     #[test]
     fn into_model_ref_from_owned_string() {
-        let model: ModelRef<OpenAi> = String::from("o1").into_model_ref();
+        let model: ModelRef = String::from("o1").into();
         assert_eq!(model.model(), "o1");
     }
 
     #[test]
     fn into_model_ref_from_model_ref_is_identity() {
-        let original = ModelRef::<OpenAi>::new("gpt-4o");
-        let converted = original.clone().into_model_ref();
-        assert_eq!(converted.model(), "gpt-4o");
+        let original = ModelRef::new("gpt-4o");
+        let cloned = original.clone();
+        assert_eq!(cloned.model(), "gpt-4o");
     }
 
     // ─── ProviderKind ────────────────────────────────────────────────────
@@ -1337,14 +1224,6 @@ mod tests {
             ProviderKind::OpenAiCompatible.as_slug(),
             "openai-compatible"
         );
-    }
-
-    #[test]
-    fn provider_marker_kind_constants() {
-        assert_eq!(OpenAi::KIND, ProviderKind::OpenAi);
-        assert_eq!(Anthropic::KIND, ProviderKind::Anthropic);
-        assert_eq!(Google::KIND, ProviderKind::Google);
-        assert_eq!(OpenAiCompatible::KIND, ProviderKind::OpenAiCompatible);
     }
 
     // ─── Message validation ──────────────────────────────────────────────
@@ -1692,7 +1571,7 @@ mod tests {
 
     #[test]
     fn agent_prepare_step_to_prepared() {
-        let step = AgentPrepareStep::<OpenAi> {
+        let step = AgentPrepareStep {
             step: 1,
             model: ModelRef::new("gpt-4o"),
             messages: vec![Message::user_text("hi")],
@@ -1822,7 +1701,7 @@ mod tests {
     #[test]
     fn builds_request_from_prompt() {
         let request =
-            GenerateTextRequest::from_user_prompt(ModelRef::<OpenAi>::new("gpt-4o-mini"), "hello");
+            GenerateTextRequest::from_user_prompt(ModelRef::new("gpt-4o-mini"), "hello");
         assert_eq!(request.messages.len(), 1);
         assert_eq!(request.model.model(), "gpt-4o-mini");
     }
@@ -1847,7 +1726,7 @@ mod tests {
 
     #[test]
     fn request_builder_rejects_invalid_top_p() {
-        let err = GenerateTextRequest::builder(ModelRef::<OpenAi>::new("gpt-4o-mini"))
+        let err = GenerateTextRequest::builder(ModelRef::new("gpt-4o-mini"))
             .message(Message::user_text("hello"))
             .top_p(1.1)
             .build()
@@ -1857,7 +1736,7 @@ mod tests {
 
     #[test]
     fn request_builder_rejects_invalid_temperature() {
-        let err = GenerateTextRequest::builder(ModelRef::<OpenAi>::new("gpt-4o-mini"))
+        let err = GenerateTextRequest::builder(ModelRef::new("gpt-4o-mini"))
             .message(Message::user_text("hello"))
             .temperature(2.1)
             .build()
@@ -1867,7 +1746,7 @@ mod tests {
 
     #[test]
     fn request_builder_rejects_empty_messages() {
-        let err = GenerateTextRequest::builder(ModelRef::<OpenAi>::new("gpt-4o-mini"))
+        let err = GenerateTextRequest::builder(ModelRef::new("gpt-4o-mini"))
             .build()
             .expect_err("empty messages should fail");
         assert!(err.message.contains("cannot be empty"));
@@ -1875,7 +1754,7 @@ mod tests {
 
     #[test]
     fn request_builder_accepts_messages_method() {
-        let req = GenerateTextRequest::builder(ModelRef::<OpenAi>::new("gpt-4o-mini"))
+        let req = GenerateTextRequest::builder(ModelRef::new("gpt-4o-mini"))
             .messages(vec![Message::user_text("h1"), Message::user_text("h2")])
             .build()
             .expect("request should build");
@@ -1884,7 +1763,7 @@ mod tests {
 
     #[test]
     fn request_builder_user_prompt_replaces_messages() {
-        let req = GenerateTextRequest::builder(ModelRef::<OpenAi>::new("gpt-4o-mini"))
+        let req = GenerateTextRequest::builder(ModelRef::new("gpt-4o-mini"))
             .message(Message::user_text("old"))
             .user_prompt("replaced")
             .build()
@@ -1894,7 +1773,7 @@ mod tests {
 
     #[test]
     fn request_builder_sets_all_fields() {
-        let req = GenerateTextRequest::builder(ModelRef::<OpenAi>::new("gpt-4o-mini"))
+        let req = GenerateTextRequest::builder(ModelRef::new("gpt-4o-mini"))
             .message(Message::user_text("hi"))
             .temperature(0.7)
             .top_p(0.9)
@@ -1912,7 +1791,7 @@ mod tests {
 
     #[test]
     fn request_builder_empty_tools_is_none() {
-        let req = GenerateTextRequest::builder(ModelRef::<OpenAi>::new("gpt-4o-mini"))
+        let req = GenerateTextRequest::builder(ModelRef::new("gpt-4o-mini"))
             .message(Message::user_text("hi"))
             .tools(Vec::<crate::tool::ToolDescriptor>::new())
             .build()
@@ -1922,7 +1801,7 @@ mod tests {
 
     #[test]
     fn request_builder_valid_temperature_boundary() {
-        let req = GenerateTextRequest::builder(ModelRef::<OpenAi>::new("gpt-4o-mini"))
+        let req = GenerateTextRequest::builder(ModelRef::new("gpt-4o-mini"))
             .message(Message::user_text("hi"))
             .temperature(2.0)
             .top_p(0.0)
@@ -1991,7 +1870,7 @@ mod tests {
 
     #[test]
     fn run_tools_builds_with_valid_config() {
-        let rt = RunTools::<OpenAi>::new(ModelRef::new("gpt-4o"))
+        let rt = RunTools::new(ModelRef::new("gpt-4o"))
             .messages([Message::user_text("hello")])
             .tools(Vec::<crate::tool::Tool>::new())
             .max_steps(5)
@@ -2008,7 +1887,7 @@ mod tests {
 
     #[test]
     fn run_tools_build_rejects_invalid_max_steps() {
-        match RunTools::<OpenAi>::new(ModelRef::new("gpt-4o"))
+        match RunTools::new(ModelRef::new("gpt-4o"))
             .messages([Message::user_text("hello")])
             .max_steps(0)
             .build()
@@ -2020,7 +1899,7 @@ mod tests {
 
     #[test]
     fn run_tools_build_rejects_invalid_model() {
-        match RunTools::<OpenAi>::new(ModelRef::new("  "))
+        match RunTools::new(ModelRef::new("  "))
             .messages([Message::user_text("hello")])
             .build()
         {
@@ -2031,7 +1910,7 @@ mod tests {
 
     #[test]
     fn run_tools_default_max_steps_is_none() {
-        let rt = RunTools::<OpenAi>::new(ModelRef::new("gpt-4o"))
+        let rt = RunTools::new(ModelRef::new("gpt-4o"))
             .messages([Message::user_text("hello")])
             .build()
             .expect("run tools should build");
@@ -2040,7 +1919,7 @@ mod tests {
 
     #[test]
     fn run_tools_default_tool_error_policy() {
-        let rt = RunTools::<OpenAi>::new(ModelRef::new("gpt-4o"))
+        let rt = RunTools::new(ModelRef::new("gpt-4o"))
             .messages([Message::user_text("hello")])
             .build()
             .expect("run tools should build");
@@ -2049,7 +1928,7 @@ mod tests {
 
     #[test]
     fn run_tools_default_tool_concurrency() {
-        let rt = RunTools::<OpenAi>::new(ModelRef::new("gpt-4o"))
+        let rt = RunTools::new(ModelRef::new("gpt-4o"))
             .messages([Message::user_text("hello")])
             .build()
             .expect("run tools should build");

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -291,6 +291,6 @@ async fn agent_prepare_step_can_override_sampling_and_on_start_sees_builder_mode
             .lock()
             .expect("start_event mutex should not be poisoned")
             .clone(),
-        Some(("openai/gpt-4.1-mini".to_string(), 1, 0, 2))
+        Some(("gpt-4.1-mini".to_string(), 1, 0, 2))
     );
 }

--- a/tests/agent_edge.rs
+++ b/tests/agent_edge.rs
@@ -1,4 +1,5 @@
 use aquaregia::{Agent, AgentPreparedStep, ErrorCode, LlmClient, Message, ToolErrorPolicy};
+use serde::Deserialize;
 use serde_json::json;
 use wiremock::matchers::{body_string_contains, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -103,7 +104,7 @@ async fn agent_stop_when_predicate_stops_early() {
     assert_eq!(response.steps, 1);
 }
 
-// ─── ToolErrorPolicy::FailFast with schema validation failure ───────────
+// ─── ToolErrorPolicy::FailFast with deserialization failure ─────────────
 
 #[tokio::test]
 async fn agent_fail_fast_on_invalid_tool_args() {
@@ -118,7 +119,7 @@ async fn agent_fail_fast_on_invalid_tool_args() {
                     "type": "function",
                     "function": {
                         "name": "weather",
-                        "arguments": "{\"bad_key\": 123}" // schema requires "city"
+                        "arguments": "{\"bad_key\": 123}" // typed executor requires "city"
                     }
                 }]
             },
@@ -139,14 +140,16 @@ async fn agent_fail_fast_on_invalid_tool_args() {
         .build()
         .expect("client should build");
 
+    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+    struct WeatherArgs {
+        city: String,
+    }
+
     let weather = aquaregia::tool("weather")
         .description("Get weather by city")
-        .raw_schema(json!({
-            "type": "object",
-            "properties": { "city": { "type": "string" } },
-            "required": ["city"]
-        }))
-        .execute_raw(|args| async move { Ok(json!({"city": args["city"], "temp": 22})) });
+        .execute(|args: WeatherArgs| async move {
+            Ok(json!({"city": args.city, "temp": 22}))
+        });
 
     let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([weather])
@@ -160,7 +163,7 @@ async fn agent_fail_fast_on_invalid_tool_args() {
         .await
         .expect_err("should fail on invalid tool args");
 
-    assert_eq!(err.code, ErrorCode::InvalidToolArgs);
+    assert_eq!(err.code, ErrorCode::ToolExecutionFailed);
 }
 
 // ─── ToolErrorPolicy::ContinueAsToolResult (default) ────────────────────

--- a/tests/agent_edge.rs
+++ b/tests/agent_edge.rs
@@ -147,9 +147,7 @@ async fn agent_fail_fast_on_invalid_tool_args() {
 
     let weather = aquaregia::tool("weather")
         .description("Get weather by city")
-        .execute(|args: WeatherArgs| async move {
-            Ok(json!({"city": args.city, "temp": 22}))
-        });
+        .execute(|args: WeatherArgs| async move { Ok(json!({"city": args.city, "temp": 22})) });
 
     let agent = Agent::builder(client, "gpt-4o-mini")
         .tools([weather])

--- a/tests/error_mapping.rs
+++ b/tests/error_mapping.rs
@@ -2,7 +2,7 @@ use aquaregia::{ErrorCode, GenerateTextRequest, LlmClient, Message};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-fn anthropic_request() -> GenerateTextRequest<aquaregia::Anthropic> {
+fn anthropic_request() -> GenerateTextRequest {
     GenerateTextRequest::builder("claude-3-5-haiku-latest")
         .message(Message::user_text("hi"))
         .temperature(0.2)

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -1,9 +1,9 @@
-use aquaregia::{ErrorCode, GenerateTextRequest, LlmClient, Message, OpenAi};
+use aquaregia::{ErrorCode, GenerateTextRequest, LlmClient, Message};
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-fn openai_request() -> GenerateTextRequest<OpenAi> {
+fn openai_request() -> GenerateTextRequest {
     GenerateTextRequest::builder("gpt-4o-mini")
         .message(Message::user_text("hello"))
         .temperature(0.2)


### PR DESCRIPTION
## Summary

- **移除 4 个外部依赖**：`base64`、`jsonschema`、`regex`、`url`，内联 base64 编码、手写 tool name 验证、改用 `reqwest::Url`，传递依赖从 349 降至 263（-86）
- **删除 ProviderMarker 幽灵类型**：移除 `OpenAi`/`Anthropic`/`Google`/`OpenAiCompatible` 空 struct、`ProviderMarker` trait、`ProviderBinding` trait、`IntoModelRef` trait；`BoundClient`、`Agent`、`AgentBuilder`、`GenerateTextRequest`、`ModelAdapter` 等全部去泛型
- **删除空 feature flags**：`openai = []`、`anthropic = []` 什么都没做，一并移除
- **文档同步**：README、README_CN 及 module doc 中的旧泛型写法全部更新；AGENTS.md 补充 Lean API Design 原则

## Behaviour changes

- `model_id()` 现在返回裸模型字符串（如 `"gpt-4o"`）而非 `"openai/gpt-4o"`
- 工具参数校验从 JSON Schema 层（注册时）下移到 serde 反序列化层（执行时）；`execute_raw` 工具不再自动校验参数
- `FailFast` 策略遇到无效参数时的错误码从 `InvalidToolArgs` 变为 `ToolExecutionFailed`

## Test plan

- [ ] `cargo test` 全量通过（145 单元测试 + 集成测试）
- [ ] 文档示例可编译