### PR TITLE
docs: sync crate description across Cargo.toml and lib.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aquaregia"
 version = "0.1.8"
 edition = "2024"
-description = "Provider-agnostic Rust toolkit for AI apps and agents."
+description = "A single crate for building LLM-powered applications and agents across any provider."
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/minorcell/aquaregia"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,6 @@
 //! # Aquaregia
 //!
-//! A provider-agnostic Rust toolkit for building AI applications and tool-using agents.
-//!
-//! Aquaregia provides a unified API across OpenAI, Anthropic, Google, and OpenAI-compatible services,
-//! with first-class support for reasoning-aware output, streaming events, multi-step tool execution,
-//! and vision/image inputs.
+//! A single crate for building LLM-powered applications and agents across any provider.
 //!
 //! ## Features
 //!


### PR DESCRIPTION
## Summary

- `Cargo.toml` `description` 和 `src/lib.rs` 顶部注释与 README 保持一致
- 统一为：*A single crate for building LLM-powered applications and agents across any provider.*

## Test plan

- [x] 无逻辑变更，仅文档/元数据同步，无需运行测试