### PR TITLE
Sync dev → main: structured output, partial_json hardening, API cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ version = "0.1.9"
 dependencies = [
  "async-stream",
  "async-trait",
+ "base64",
  "futures-core",
  "futures-util",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ telemetry = ["dep:tracing"]
 
 async-stream = "0.3"
 async-trait = "0.1"
+base64 = "0.22"
 futures-core = "0.3"
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -48,9 +48,8 @@ use crate::client::BoundClient;
 use crate::tool::{IntoTool, Tool};
 use crate::types::{
     AgentFinish, AgentPrepareStep, AgentPreparedStep, AgentResponse, AgentStart, AgentStep,
-    AgentStepStart, AgentToolCallFinish, AgentToolCallStart, Hook, Message, ModelRef,
-    PrepareStepHook, RunTools, StopPredicate, ToolErrorPolicy, validate_model_ref,
-    validate_sampling,
+    AgentStepStart, AgentToolCallFinish, AgentToolCallStart, Hook, Message, PrepareStepHook,
+    RunTools, StopPredicate, ToolErrorPolicy, validate_model_ref, validate_sampling,
 };
 
 /// Multi-step tool-using agent bound to one provider and one default model.
@@ -70,7 +69,7 @@ use crate::types::{
 /// - **Error policies**: Configurable tool error handling (`ContinueAsToolResult` or `FailFast`)
 pub struct Agent {
     client: Arc<BoundClient>,
-    model: ModelRef,
+    model: String,
     instructions: Option<String>,
     tools: Vec<Tool>,
     max_steps: Option<u32>,
@@ -94,14 +93,14 @@ impl Agent {
     /// Starts building an [`Agent`] from a provider-bound client and model.
     pub fn builder(
         client: impl Into<Arc<BoundClient>>,
-        model: impl Into<ModelRef>,
+        model: impl Into<String>,
     ) -> AgentBuilder {
         AgentBuilder::new(client.into(), model.into())
     }
 
     /// Returns the fully qualified model id (`<provider>/<model>`).
     pub fn model_id(&self) -> String {
-        self.model.model().to_string()
+        self.model.clone()
     }
 
     /// Prepends instructions as a system message if configured and no system
@@ -210,7 +209,7 @@ impl Agent {
 /// Builder for configuring an [`Agent`].
 pub struct AgentBuilder {
     client: Arc<BoundClient>,
-    model: ModelRef,
+    model: String,
     instructions: Option<String>,
     tools: Vec<Tool>,
     max_steps: Option<u32>,
@@ -231,7 +230,7 @@ pub struct AgentBuilder {
 }
 
 impl AgentBuilder {
-    fn new(client: Arc<BoundClient>, model: ModelRef) -> Self {
+    fn new(client: Arc<BoundClient>, model: String) -> Self {
         Self {
             client,
             model,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -75,10 +75,7 @@ pub struct Agent {
 
 impl Agent {
     /// Starts building an [`Agent`] from a provider-bound client and model.
-    pub fn builder(
-        client: impl Into<Arc<BoundClient>>,
-        model: impl Into<String>,
-    ) -> AgentBuilder {
+    pub fn builder(client: impl Into<Arc<BoundClient>>, model: impl Into<String>) -> AgentBuilder {
         AgentBuilder::new(client.into(), model.into())
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -45,11 +45,11 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use crate::client::BoundClient;
-use crate::tool::{IntoTool, Tool};
+use crate::tool::IntoTool;
 use crate::types::{
     AgentFinish, AgentPrepareStep, AgentPreparedStep, AgentResponse, AgentStart, AgentStep,
-    AgentStepStart, AgentToolCallFinish, AgentToolCallStart, Hook, Message, PrepareStepHook,
-    RunTools, StopPredicate, ToolErrorPolicy, validate_model_ref, validate_sampling,
+    AgentStepStart, AgentToolCallFinish, AgentToolCallStart, Message, RunTools, ToolErrorPolicy,
+    validate_model_ref, validate_sampling,
 };
 
 /// Multi-step tool-using agent bound to one provider and one default model.
@@ -69,24 +69,8 @@ use crate::types::{
 /// - **Error policies**: Configurable tool error handling (`ContinueAsToolResult` or `FailFast`)
 pub struct Agent {
     client: Arc<BoundClient>,
-    model: String,
     instructions: Option<String>,
-    tools: Vec<Tool>,
-    max_steps: Option<u32>,
-    temperature: Option<f32>,
-    top_p: Option<f32>,
-    max_output_tokens: Option<u32>,
-    stop_sequences: Vec<String>,
-    cancellation_token: Option<CancellationToken>,
-    prepare_step: Option<PrepareStepHook>,
-    on_start: Option<Hook<AgentStart>>,
-    on_step_start: Option<Hook<AgentStepStart>>,
-    on_tool_call_start: Option<Hook<AgentToolCallStart>>,
-    on_tool_call_finish: Option<Hook<AgentToolCallFinish>>,
-    on_step_finish: Option<Hook<AgentStep>>,
-    on_finish: Option<Hook<AgentFinish>>,
-    stop_when: Option<StopPredicate>,
-    tool_error_policy: ToolErrorPolicy,
+    template: RunTools,
 }
 
 impl Agent {
@@ -100,7 +84,7 @@ impl Agent {
 
     /// Returns the fully qualified model id (`<provider>/<model>`).
     pub fn model_id(&self) -> String {
-        self.model.clone()
+        self.template.model.clone()
     }
 
     /// Prepends instructions as a system message if configured and no system
@@ -145,63 +129,8 @@ impl Agent {
         &self,
         messages: Vec<Message>,
     ) -> Result<AgentResponse, crate::error::Error> {
-        let mut request = RunTools::new(self.model.clone())
-            .messages(messages)
-            .tools(self.tools.clone())
-            .tool_error_policy(self.tool_error_policy)
-            .stop_sequences(self.stop_sequences.clone());
-
-        if let Some(t) = &self.cancellation_token {
-            request = request.cancellation_token(t.clone());
-        }
-        if let Some(max_steps) = self.max_steps {
-            request = request.max_steps(max_steps);
-        }
-        if let Some(temperature) = self.temperature {
-            request = request.temperature(temperature);
-        }
-        if let Some(top_p) = self.top_p {
-            request = request.top_p(top_p);
-        }
-        if let Some(max_output_tokens) = self.max_output_tokens {
-            request = request.max_output_tokens(max_output_tokens);
-        }
-
-        if let Some(prepare_step) = &self.prepare_step {
-            let prepare_step = prepare_step.clone();
-            request = request.prepare_step(move |event| prepare_step(event));
-        }
-        if let Some(on_start) = &self.on_start {
-            let on_start = on_start.clone();
-            request = request.on_start(move |event: &AgentStart| on_start(event));
-        }
-        if let Some(on_step_start) = &self.on_step_start {
-            let on_step_start = on_step_start.clone();
-            request = request.on_step_start(move |event: &AgentStepStart| on_step_start(event));
-        }
-        if let Some(on_tool_call_start) = &self.on_tool_call_start {
-            let on_tool_call_start = on_tool_call_start.clone();
-            request = request
-                .on_tool_call_start(move |event: &AgentToolCallStart| on_tool_call_start(event));
-        }
-        if let Some(on_tool_call_finish) = &self.on_tool_call_finish {
-            let on_tool_call_finish = on_tool_call_finish.clone();
-            request = request
-                .on_tool_call_finish(move |event: &AgentToolCallFinish| on_tool_call_finish(event));
-        }
-        if let Some(on_step_finish) = &self.on_step_finish {
-            let on_step_finish = on_step_finish.clone();
-            request = request.on_step_finish(move |event: &AgentStep| on_step_finish(event));
-        }
-        if let Some(on_finish) = &self.on_finish {
-            let on_finish = on_finish.clone();
-            request = request.on_finish(move |event: &AgentFinish| on_finish(event));
-        }
-        if let Some(stop_when) = &self.stop_when {
-            let stop_when = stop_when.clone();
-            request = request.stop_when(move |step: &AgentStep| stop_when(step));
-        }
-
+        let mut request = self.template.clone();
+        request.messages = messages;
         self.client.run_tools(request.build()?).await
     }
 }
@@ -209,48 +138,16 @@ impl Agent {
 /// Builder for configuring an [`Agent`].
 pub struct AgentBuilder {
     client: Arc<BoundClient>,
-    model: String,
     instructions: Option<String>,
-    tools: Vec<Tool>,
-    max_steps: Option<u32>,
-    temperature: Option<f32>,
-    top_p: Option<f32>,
-    max_output_tokens: Option<u32>,
-    stop_sequences: Vec<String>,
-    cancellation_token: Option<CancellationToken>,
-    prepare_step: Option<PrepareStepHook>,
-    on_start: Option<Hook<AgentStart>>,
-    on_step_start: Option<Hook<AgentStepStart>>,
-    on_tool_call_start: Option<Hook<AgentToolCallStart>>,
-    on_tool_call_finish: Option<Hook<AgentToolCallFinish>>,
-    on_step_finish: Option<Hook<AgentStep>>,
-    on_finish: Option<Hook<AgentFinish>>,
-    stop_when: Option<StopPredicate>,
-    tool_error_policy: ToolErrorPolicy,
+    template: RunTools,
 }
 
 impl AgentBuilder {
     fn new(client: Arc<BoundClient>, model: String) -> Self {
         Self {
             client,
-            model,
             instructions: None,
-            tools: Vec::new(),
-            max_steps: None,
-            temperature: None,
-            top_p: None,
-            max_output_tokens: None,
-            stop_sequences: Vec::new(),
-            cancellation_token: None,
-            prepare_step: None,
-            on_start: None,
-            on_step_start: None,
-            on_tool_call_start: None,
-            on_tool_call_finish: None,
-            on_step_finish: None,
-            on_finish: None,
-            stop_when: None,
-            tool_error_policy: ToolErrorPolicy::ContinueAsToolResult,
+            template: RunTools::new(model),
         }
     }
 
@@ -266,8 +163,7 @@ impl AgentBuilder {
         I: IntoIterator<Item = T>,
         T: IntoTool,
     {
-        self.tools
-            .extend(tools.into_iter().map(IntoTool::into_tool));
+        self.template = self.template.tools(tools);
         self
     }
 
@@ -278,25 +174,25 @@ impl AgentBuilder {
     /// cancelled). When not set, falls back to the client's `default_max_steps`
     /// (which is `0` / unlimited by default).
     pub fn max_steps(mut self, max_steps: u32) -> Self {
-        self.max_steps = Some(max_steps);
+        self.template = self.template.max_steps(max_steps);
         self
     }
 
     /// Sets default sampling temperature in range `0.0..=2.0`.
     pub fn temperature(mut self, temperature: f32) -> Self {
-        self.temperature = Some(temperature);
+        self.template = self.template.temperature(temperature);
         self
     }
 
     /// Sets default nucleus sampling value in range `0.0..=1.0`.
     pub fn top_p(mut self, top_p: f32) -> Self {
-        self.top_p = Some(top_p);
+        self.template = self.template.top_p(top_p);
         self
     }
 
     /// Sets default maximum output token budget per step.
     pub fn max_output_tokens(mut self, max_output_tokens: u32) -> Self {
-        self.max_output_tokens = Some(max_output_tokens);
+        self.template = self.template.max_output_tokens(max_output_tokens);
         self
     }
 
@@ -305,8 +201,7 @@ impl AgentBuilder {
         mut self,
         stop_sequences: impl IntoIterator<Item = S>,
     ) -> Self {
-        self.stop_sequences
-            .extend(stop_sequences.into_iter().map(Into::into));
+        self.template = self.template.stop_sequences(stop_sequences);
         self
     }
 
@@ -316,7 +211,7 @@ impl AgentBuilder {
     /// [`crate::ErrorCode::Cancelled`]. To cancel different runs independently, build
     /// a separate agent per token.
     pub fn cancellation_token(mut self, token: CancellationToken) -> Self {
-        self.cancellation_token = Some(token);
+        self.template = self.template.cancellation_token(token);
         self
     }
 
@@ -325,7 +220,7 @@ impl AgentBuilder {
     where
         F: Fn(&AgentPrepareStep) -> AgentPreparedStep + Send + Sync + 'static,
     {
-        self.prepare_step = Some(Arc::new(callback));
+        self.template = self.template.prepare_step(callback);
         self
     }
 
@@ -334,7 +229,7 @@ impl AgentBuilder {
     where
         F: Fn(&AgentStep) + Send + Sync + 'static,
     {
-        self.on_step_finish = Some(Arc::new(callback));
+        self.template = self.template.on_step_finish(callback);
         self
     }
 
@@ -343,7 +238,7 @@ impl AgentBuilder {
     where
         F: Fn(&AgentStart) + Send + Sync + 'static,
     {
-        self.on_start = Some(Arc::new(callback));
+        self.template = self.template.on_start(callback);
         self
     }
 
@@ -352,7 +247,7 @@ impl AgentBuilder {
     where
         F: Fn(&AgentStepStart) + Send + Sync + 'static,
     {
-        self.on_step_start = Some(Arc::new(callback));
+        self.template = self.template.on_step_start(callback);
         self
     }
 
@@ -361,7 +256,7 @@ impl AgentBuilder {
     where
         F: Fn(&AgentToolCallStart) + Send + Sync + 'static,
     {
-        self.on_tool_call_start = Some(Arc::new(callback));
+        self.template = self.template.on_tool_call_start(callback);
         self
     }
 
@@ -370,7 +265,7 @@ impl AgentBuilder {
     where
         F: Fn(&AgentToolCallFinish) + Send + Sync + 'static,
     {
-        self.on_tool_call_finish = Some(Arc::new(callback));
+        self.template = self.template.on_tool_call_finish(callback);
         self
     }
 
@@ -379,7 +274,7 @@ impl AgentBuilder {
     where
         F: Fn(&AgentFinish) + Send + Sync + 'static,
     {
-        self.on_finish = Some(Arc::new(callback));
+        self.template = self.template.on_finish(callback);
         self
     }
 
@@ -388,41 +283,25 @@ impl AgentBuilder {
     where
         F: Fn(&AgentStep) -> bool + Send + Sync + 'static,
     {
-        self.stop_when = Some(Arc::new(predicate));
+        self.template = self.template.stop_when(predicate);
         self
     }
 
     /// Controls how tool execution errors are handled inside the loop.
     pub fn tool_error_policy(mut self, policy: ToolErrorPolicy) -> Self {
-        self.tool_error_policy = policy;
+        self.template = self.template.tool_error_policy(policy);
         self
     }
 
     /// Validates configuration and builds the [`Agent`].
     pub fn build(self) -> Result<Agent, crate::error::Error> {
-        validate_model_ref(&self.model)?;
-        validate_sampling(self.temperature, self.top_p)?;
+        validate_model_ref(&self.template.model)?;
+        validate_sampling(self.template.temperature, self.template.top_p)?;
 
         Ok(Agent {
             client: self.client,
-            model: self.model,
             instructions: self.instructions,
-            tools: self.tools,
-            max_steps: self.max_steps,
-            temperature: self.temperature,
-            top_p: self.top_p,
-            max_output_tokens: self.max_output_tokens,
-            stop_sequences: self.stop_sequences,
-            cancellation_token: self.cancellation_token,
-            prepare_step: self.prepare_step,
-            on_start: self.on_start,
-            on_step_start: self.on_step_start,
-            on_tool_call_start: self.on_tool_call_start,
-            on_tool_call_finish: self.on_tool_call_finish,
-            on_step_finish: self.on_step_finish,
-            on_finish: self.on_finish,
-            stop_when: self.stop_when,
-            tool_error_policy: self.tool_error_policy,
+            template: self.template,
         })
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -60,9 +60,24 @@ use crate::types::{
     validate_messages, validate_model_ref, validate_sampling,
 };
 
-#[doc(hidden)]
-pub trait BuildProvider {
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::OpenAiAdapterSettings {}
+    impl Sealed for super::AnthropicAdapterSettings {}
+    impl Sealed for super::GoogleAdapterSettings {}
+    impl Sealed for super::OpenAiCompatibleAdapterSettings {}
+}
+
+/// Provider-settings contract consumed by [`ClientBuilder`].
+///
+/// This trait is sealed: it is implemented exactly for the four built-in
+/// `*AdapterSettings` types and cannot be implemented downstream. External
+/// providers should add an adapter to the `model_adapters` module rather
+/// than implementing this trait.
+pub trait BuildProvider: sealed::Sealed {
+    #[doc(hidden)]
     fn validate(&self) -> Result<(), Error>;
+    #[doc(hidden)]
     fn into_adapter(self, http: Arc<reqwest::Client>) -> Arc<dyn ModelAdapter>;
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -528,7 +528,7 @@ impl BoundClient {
 
         if let Some(callback) = &on_start {
             callback(&AgentStart {
-                model_id: model.model().to_string(),
+                model_id: model.clone(),
                 messages: messages.clone(),
                 tool_count: tools.len(),
                 max_steps: resolved_max_steps,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,6 @@ pub use types::{
     MediaData,
     Message,
     MessageRole,
-    ModelRef,
     ObjectStream,
     OutputSchema,
     ReasoningPart,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,6 @@ pub use types::{
     ModelRef,
     ObjectStream,
     OutputSchema,
-    ProviderKind,
     ReasoningPart,
     StreamEvent,
     StreamObjectEvent,

--- a/src/model_adapters/anthropic/mod.rs
+++ b/src/model_adapters/anthropic/mod.rs
@@ -431,7 +431,7 @@ fn build_anthropic_payload(req: &GenerateTextRequest, stream: bool) -> Value {
     let mut payload = Map::new();
     payload.insert(
         "model".to_string(),
-        Value::String(req.model.model().to_string()),
+        Value::String(req.model.clone()),
     );
     payload.insert(
         "messages".to_string(),

--- a/src/model_adapters/anthropic/mod.rs
+++ b/src/model_adapters/anthropic/mod.rs
@@ -429,10 +429,7 @@ impl PendingToolUse {
 
 fn build_anthropic_payload(req: &GenerateTextRequest, stream: bool) -> Value {
     let mut payload = Map::new();
-    payload.insert(
-        "model".to_string(),
-        Value::String(req.model.clone()),
-    );
+    payload.insert("model".to_string(), Value::String(req.model.clone()));
     payload.insert(
         "messages".to_string(),
         Value::Array(

--- a/src/model_adapters/google/mod.rs
+++ b/src/model_adapters/google/mod.rs
@@ -119,7 +119,7 @@ impl ModelAdapter for GoogleAdapter {
         let cancel_token = req.cancellation_token.clone();
         let send_fut = self
             .http
-            .post(self.generate_url(req.model.model()))
+            .post(self.generate_url(req.model.as_str()))
             .header("x-goog-api-key", &self.api_key)
             .header(CONTENT_TYPE, "application/json")
             .json(&payload)
@@ -156,7 +156,7 @@ impl ModelAdapter for GoogleAdapter {
         let cancel_token_stream = cancel_token.clone();
         let send_fut = self
             .http
-            .post(self.stream_url(req.model.model()))
+            .post(self.stream_url(req.model.as_str()))
             .header("x-goog-api-key", &self.api_key)
             .header(CONTENT_TYPE, "application/json")
             .json(&payload)

--- a/src/model_adapters/mod.rs
+++ b/src/model_adapters/mod.rs
@@ -43,6 +43,7 @@
 //! ```
 
 use async_trait::async_trait;
+use base64::{Engine, engine::general_purpose::STANDARD};
 use reqwest::Response;
 
 use crate::error::Error;
@@ -101,25 +102,5 @@ pub(crate) fn map_send_error(provider_id: &str, err: reqwest::Error) -> Error {
 }
 
 pub(crate) fn base64_encode(data: &[u8]) -> String {
-    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
-    for chunk in data.chunks(3) {
-        let b0 = chunk[0] as usize;
-        let b1 = chunk.get(1).copied().unwrap_or(0) as usize;
-        let b2 = chunk.get(2).copied().unwrap_or(0) as usize;
-        let n = (b0 << 16) | (b1 << 8) | b2;
-        out.push(CHARS[(n >> 18) & 0x3f] as char);
-        out.push(CHARS[(n >> 12) & 0x3f] as char);
-        out.push(if chunk.len() > 1 {
-            CHARS[(n >> 6) & 0x3f] as char
-        } else {
-            '='
-        });
-        out.push(if chunk.len() > 2 {
-            CHARS[n & 0x3f] as char
-        } else {
-            '='
-        });
-    }
-    out
+    STANDARD.encode(data)
 }

--- a/src/model_adapters/openai/mod.rs
+++ b/src/model_adapters/openai/mod.rs
@@ -393,7 +393,7 @@ fn build_payload(req: &GenerateTextRequest, stream: bool) -> Value {
     let mut payload = Map::new();
     payload.insert(
         "model".to_string(),
-        Value::String(req.model.model().to_string()),
+        Value::String(req.model.clone()),
     );
     payload.insert("stream".to_string(), Value::Bool(stream));
 

--- a/src/model_adapters/openai/mod.rs
+++ b/src/model_adapters/openai/mod.rs
@@ -391,10 +391,7 @@ struct PartialFnCall {
 /// Builds the Responses API request payload.
 fn build_payload(req: &GenerateTextRequest, stream: bool) -> Value {
     let mut payload = Map::new();
-    payload.insert(
-        "model".to_string(),
-        Value::String(req.model.clone()),
-    );
+    payload.insert("model".to_string(), Value::String(req.model.clone()));
     payload.insert("stream".to_string(), Value::Bool(stream));
 
     // System messages become the top-level `instructions` field.

--- a/src/model_adapters/openai_compatible/mod.rs
+++ b/src/model_adapters/openai_compatible/mod.rs
@@ -502,10 +502,7 @@ impl PartialToolCall {
 
 fn build_openai_payload(req: &GenerateTextRequest, stream: bool) -> Value {
     let mut payload = Map::new();
-    payload.insert(
-        "model".to_string(),
-        Value::String(req.model.clone()),
-    );
+    payload.insert("model".to_string(), Value::String(req.model.clone()));
     payload.insert(
         "messages".to_string(),
         Value::Array(req.messages.iter().map(to_openai_message).collect()),

--- a/src/model_adapters/openai_compatible/mod.rs
+++ b/src/model_adapters/openai_compatible/mod.rs
@@ -504,7 +504,7 @@ fn build_openai_payload(req: &GenerateTextRequest, stream: bool) -> Value {
     let mut payload = Map::new();
     payload.insert(
         "model".to_string(),
-        Value::String(req.model.model().to_string()),
+        Value::String(req.model.clone()),
     );
     payload.insert(
         "messages".to_string(),

--- a/src/partial_json.rs
+++ b/src/partial_json.rs
@@ -137,13 +137,12 @@ pub(crate) fn repair_json(input: &str) -> String {
                 _ => {}
             },
 
-            State::InsideObjectAfterComma => match c {
-                '"' => {
+            State::InsideObjectAfterComma => {
+                if c == '"' {
                     stack.pop();
                     stack.push(State::InsideObjectKey);
                 }
-                _ => {}
-            },
+            }
 
             State::InsideObjectKey => {
                 // We're inside a key string — just wait for the closing quote.
@@ -160,13 +159,12 @@ pub(crate) fn repair_json(input: &str) -> String {
                 }
             }
 
-            State::InsideObjectAfterKey => match c {
-                ':' => {
+            State::InsideObjectAfterKey => {
+                if c == ':' {
                     stack.pop();
                     stack.push(State::InsideObjectBeforeValue);
                 }
-                _ => {}
-            },
+            }
 
             State::InsideObjectBeforeValue => {
                 process_value_start(

--- a/src/partial_json.rs
+++ b/src/partial_json.rs
@@ -62,53 +62,52 @@ pub(crate) fn repair_json(input: &str) -> String {
     let mut unicode_hex_remaining: u8 = 0;
 
     // Helper: push `swap` before the new value state.
-    let process_value_start =
-        |stack: &mut Vec<State>,
-         c: char,
-         swap: State,
-         last_valid_index: &mut i64,
-         literal_start: &mut Option<usize>,
-         i: usize| {
-            match c {
-                '"' => {
-                    *last_valid_index = i as i64;
-                    stack.pop();
-                    stack.push(swap);
-                    stack.push(State::InsideString);
-                }
-                'f' | 't' | 'n' => {
-                    *last_valid_index = i as i64;
-                    *literal_start = Some(i);
-                    stack.pop();
-                    stack.push(swap);
-                    stack.push(State::InsideLiteral);
-                }
-                '-' => {
-                    stack.pop();
-                    stack.push(swap);
-                    stack.push(State::InsideNumber);
-                }
-                '0'..='9' => {
-                    *last_valid_index = i as i64;
-                    stack.pop();
-                    stack.push(swap);
-                    stack.push(State::InsideNumber);
-                }
-                '{' => {
-                    *last_valid_index = i as i64;
-                    stack.pop();
-                    stack.push(swap);
-                    stack.push(State::InsideObjectStart);
-                }
-                '[' => {
-                    *last_valid_index = i as i64;
-                    stack.pop();
-                    stack.push(swap);
-                    stack.push(State::InsideArrayStart);
-                }
-                _ => {}
+    let process_value_start = |stack: &mut Vec<State>,
+                               c: char,
+                               swap: State,
+                               last_valid_index: &mut i64,
+                               literal_start: &mut Option<usize>,
+                               i: usize| {
+        match c {
+            '"' => {
+                *last_valid_index = i as i64;
+                stack.pop();
+                stack.push(swap);
+                stack.push(State::InsideString);
             }
-        };
+            'f' | 't' | 'n' => {
+                *last_valid_index = i as i64;
+                *literal_start = Some(i);
+                stack.pop();
+                stack.push(swap);
+                stack.push(State::InsideLiteral);
+            }
+            '-' => {
+                stack.pop();
+                stack.push(swap);
+                stack.push(State::InsideNumber);
+            }
+            '0'..='9' => {
+                *last_valid_index = i as i64;
+                stack.pop();
+                stack.push(swap);
+                stack.push(State::InsideNumber);
+            }
+            '{' => {
+                *last_valid_index = i as i64;
+                stack.pop();
+                stack.push(swap);
+                stack.push(State::InsideObjectStart);
+            }
+            '[' => {
+                *last_valid_index = i as i64;
+                stack.pop();
+                stack.push(swap);
+                stack.push(State::InsideArrayStart);
+            }
+            _ => {}
+        }
+    };
 
     for i in 0..n {
         let c = chars[i];
@@ -117,7 +116,12 @@ pub(crate) fn repair_json(input: &str) -> String {
         match current {
             State::Root => {
                 process_value_start(
-                    &mut stack, c, State::Finish, &mut last_valid_index, &mut literal_start, i,
+                    &mut stack,
+                    c,
+                    State::Finish,
+                    &mut last_valid_index,
+                    &mut literal_start,
+                    i,
                 );
             }
 
@@ -529,7 +533,10 @@ mod tests {
     fn complete_array_of_objects() {
         let s = r#"{"people":[{"name":"A"},{"name":"B"}]}"#;
         let v = parse_value(s).unwrap();
-        assert_eq!(v, serde_json::json!({"people": [{"name": "A"}, {"name": "B"}]}));
+        assert_eq!(
+            v,
+            serde_json::json!({"people": [{"name": "A"}, {"name": "B"}]})
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -871,10 +878,7 @@ mod tests {
         let partial = r#"{"people":[{"name":"A"},{"na"#;
         let v = parse_value(partial).unwrap();
         // Truncated key inside second object — `{` was valid so we get an empty `{}`.
-        assert_eq!(
-            v,
-            serde_json::json!({"people": [{"name": "A"}, {}]})
-        );
+        assert_eq!(v, serde_json::json!({"people": [{"name": "A"}, {}]}));
     }
 
     #[test]
@@ -978,10 +982,7 @@ mod tests {
     fn comma_inside_string_does_not_switch_stage() {
         let s = r#"{"greeting":"hello, world"}"#;
         let v = parse_value(s).unwrap();
-        assert_eq!(
-            v,
-            serde_json::json!({"greeting": "hello, world"})
-        );
+        assert_eq!(v, serde_json::json!({"greeting": "hello, world"}));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -484,11 +484,6 @@ impl RunTools {
         }
     }
 
-    pub(crate) fn messages(mut self, messages: impl IntoIterator<Item = Message>) -> Self {
-        self.messages = messages.into_iter().collect();
-        self
-    }
-
     pub(crate) fn tools<I, T>(mut self, tools: I) -> Self
     where
         I: IntoIterator<Item = T>,
@@ -1770,10 +1765,15 @@ mod tests {
 
     // ─── RunTools builder ────────────────────────────────────────────────
 
+    fn run_tools_with_messages(model: &str) -> RunTools {
+        let mut rt = RunTools::new(model);
+        rt.messages = vec![Message::user_text("hello")];
+        rt
+    }
+
     #[test]
     fn run_tools_builds_with_valid_config() {
-        let rt = RunTools::new("gpt-5.5")
-            .messages([Message::user_text("hello")])
+        let rt = run_tools_with_messages("gpt-5.5")
             .tools(Vec::<crate::tool::Tool>::new())
             .max_steps(5)
             .temperature(0.5)
@@ -1789,8 +1789,7 @@ mod tests {
 
     #[test]
     fn run_tools_build_accepts_zero_max_steps_as_unlimited() {
-        let req = RunTools::new("gpt-5.5")
-            .messages([Message::user_text("hello")])
+        let req = run_tools_with_messages("gpt-5.5")
             .max_steps(0)
             .build()
             .expect("0 max_steps is allowed and means unlimited");
@@ -1799,10 +1798,7 @@ mod tests {
 
     #[test]
     fn run_tools_build_rejects_invalid_model() {
-        match RunTools::new("  ")
-            .messages([Message::user_text("hello")])
-            .build()
-        {
+        match run_tools_with_messages("  ").build() {
             Err(err) => assert!(err.message.contains("cannot be empty")),
             Ok(_) => panic!("should have failed"),
         }
@@ -1810,8 +1806,7 @@ mod tests {
 
     #[test]
     fn run_tools_default_max_steps_is_none() {
-        let rt = RunTools::new("gpt-5.5")
-            .messages([Message::user_text("hello")])
+        let rt = run_tools_with_messages("gpt-5.5")
             .build()
             .expect("run tools should build");
         assert_eq!(rt.max_steps, None);
@@ -1819,8 +1814,7 @@ mod tests {
 
     #[test]
     fn run_tools_default_tool_error_policy() {
-        let rt = RunTools::new("gpt-5.5")
-            .messages([Message::user_text("hello")])
+        let rt = run_tools_with_messages("gpt-5.5")
             .build()
             .expect("run tools should build");
         assert_eq!(rt.tool_error_policy, ToolErrorPolicy::ContinueAsToolResult);

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,53 +18,6 @@ use serde_json::Value;
 use crate::error::{Error, ErrorCode};
 use crate::tool::{IntoTool, Tool, ToolDescriptor};
 
-/// Model reference: a provider-local model identifier string.
-///
-/// # Example
-///
-/// ```
-/// use aquaregia::ModelRef;
-///
-/// let model = ModelRef::new("gpt-5.5");
-/// assert_eq!(model.model(), "gpt-5.5");
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ModelRef {
-    model: String,
-}
-
-impl ModelRef {
-    /// Creates a model reference from a model id string.
-    pub fn new(model: impl Into<String>) -> Self {
-        Self {
-            model: model.into(),
-        }
-    }
-
-    /// Returns the model id string.
-    pub fn model(&self) -> &str {
-        &self.model
-    }
-}
-
-impl std::fmt::Display for ModelRef {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.model)
-    }
-}
-
-impl From<&str> for ModelRef {
-    fn from(s: &str) -> Self {
-        ModelRef::new(s)
-    }
-}
-
-impl From<String> for ModelRef {
-    fn from(s: String) -> Self {
-        ModelRef::new(s)
-    }
-}
-
 /// Chat message role used across providers.
 ///
 /// This enum represents the standard roles in a multi-turn conversation,
@@ -339,7 +292,7 @@ pub struct OutputSchema {
 /// Request for generation/streaming calls.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GenerateTextRequest {
-    pub(crate) model: ModelRef,
+    pub(crate) model: String,
     pub(crate) messages: Vec<Message>,
     pub(crate) temperature: Option<f32>,
     pub(crate) top_p: Option<f32>,
@@ -358,7 +311,7 @@ impl GenerateTextRequest {
     }
 
     /// Builds a one-message request from a user prompt.
-    pub fn from_user_prompt(model: impl Into<ModelRef>, prompt: impl Into<String>) -> Self {
+    pub fn from_user_prompt(model: impl Into<String>, prompt: impl Into<String>) -> Self {
         Self {
             model: model.into(),
             messages: vec![Message::user_text(prompt)],
@@ -373,7 +326,7 @@ impl GenerateTextRequest {
     }
 
     /// Starts a request builder.
-    pub fn builder(model: impl Into<ModelRef>) -> GenerateTextRequestBuilder {
+    pub fn builder(model: impl Into<String>) -> GenerateTextRequestBuilder {
         GenerateTextRequestBuilder {
             request: Self {
                 model: model.into(),
@@ -487,7 +440,7 @@ pub enum ToolErrorPolicy {
 
 #[derive(Clone)]
 pub(crate) struct RunTools {
-    pub(crate) model: ModelRef,
+    pub(crate) model: String,
     pub(crate) messages: Vec<Message>,
     pub(crate) tools: Vec<Tool>,
     pub(crate) max_steps: Option<u32>,
@@ -508,7 +461,7 @@ pub(crate) struct RunTools {
 }
 
 impl RunTools {
-    pub(crate) fn new(model: impl Into<ModelRef>) -> Self {
+    pub(crate) fn new(model: impl Into<String>) -> Self {
         Self {
             model: model.into(),
             messages: Vec::new(),
@@ -746,7 +699,7 @@ pub struct AgentPrepareStep {
     /// 1-based step index to be executed.
     pub step: u32,
     /// Model selected for this step.
-    pub model: ModelRef,
+    pub model: String,
     /// Messages that will be sent unless changed.
     pub messages: Vec<Message>,
     /// Tools currently available for this step.
@@ -765,7 +718,7 @@ pub struct AgentPrepareStep {
 #[derive(Debug, Clone)]
 pub struct AgentPreparedStep {
     /// Model selected for this step.
-    pub model: ModelRef,
+    pub model: String,
     /// Messages to send for this step.
     pub messages: Vec<Message>,
     /// Tools available for this step.
@@ -1149,8 +1102,8 @@ pub(crate) fn validate_messages(messages: &[Message]) -> Result<(), Error> {
     Ok(())
 }
 
-pub(crate) fn validate_model_ref(model: &ModelRef) -> Result<(), Error> {
-    if model.model().trim().is_empty() {
+pub(crate) fn validate_model_ref(model: &str) -> Result<(), Error> {
+    if model.trim().is_empty() {
         return Err(Error::new(
             ErrorCode::InvalidRequest,
             "model name cannot be empty",
@@ -1183,56 +1136,16 @@ pub(crate) fn validate_sampling(temperature: Option<f32>, top_p: Option<f32>) ->
 mod tests {
     use super::*;
 
-    // ─── ModelRef ────────────────────────────────────────────────────────
-
-    #[test]
-    fn builds_openai_model() {
-        let model = ModelRef::new("gpt-5.4-mini");
-        assert_eq!(model.model(), "gpt-5.4-mini");
-    }
+    // ─── Model validation ────────────────────────────────────────────────
 
     #[test]
     fn rejects_empty_model_name() {
-        let model = ModelRef::new("  ");
-        let err = validate_model_ref(&model).expect_err("empty model should fail");
+        let err = validate_model_ref("  ").expect_err("empty model should fail");
         assert!(
             err.message.contains("cannot be empty"),
             "unexpected error: {}",
             err.message
         );
-    }
-
-    #[test]
-    fn model_ref_display_matches_model_id() {
-        let model = ModelRef::new("gpt-5.4-mini");
-        assert_eq!(model.to_string(), "gpt-5.4-mini");
-    }
-
-    #[test]
-    fn model_ref_serialization_roundtrip() {
-        let model = ModelRef::new("gpt-5.5");
-        let json = serde_json::to_string(&model).unwrap();
-        let deserialized: ModelRef = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.model(), "gpt-5.5");
-    }
-
-    #[test]
-    fn into_model_ref_from_string() {
-        let model: ModelRef = "gpt-5.5".into();
-        assert_eq!(model.model(), "gpt-5.5");
-    }
-
-    #[test]
-    fn into_model_ref_from_owned_string() {
-        let model: ModelRef = String::from("o1").into();
-        assert_eq!(model.model(), "o1");
-    }
-
-    #[test]
-    fn into_model_ref_from_model_ref_is_identity() {
-        let original = ModelRef::new("gpt-5.5");
-        let cloned = original.clone();
-        assert_eq!(cloned.model(), "gpt-5.5");
     }
 
     // ─── Message validation ──────────────────────────────────────────────
@@ -1582,7 +1495,7 @@ mod tests {
     fn agent_prepare_step_to_prepared() {
         let step = AgentPrepareStep {
             step: 1,
-            model: ModelRef::new("gpt-5.5"),
+            model: "gpt-5.5".to_string(),
             messages: vec![Message::user_text("hi")],
             tools: vec![],
             temperature: Some(0.5),
@@ -1591,7 +1504,7 @@ mod tests {
             previous_steps: vec![],
         };
         let prepared = step.to_prepared();
-        assert_eq!(prepared.model.model(), "gpt-5.5");
+        assert_eq!(prepared.model.as_str(), "gpt-5.5");
         assert_eq!(prepared.temperature, Some(0.5));
         assert_eq!(prepared.max_output_tokens, Some(100));
         assert_eq!(prepared.messages.len(), 1);
@@ -1709,9 +1622,9 @@ mod tests {
 
     #[test]
     fn builds_request_from_prompt() {
-        let request = GenerateTextRequest::from_user_prompt(ModelRef::new("gpt-5.4-mini"), "hello");
+        let request = GenerateTextRequest::from_user_prompt("gpt-5.4-mini", "hello");
         assert_eq!(request.messages.len(), 1);
-        assert_eq!(request.model.model(), "gpt-5.4-mini");
+        assert_eq!(request.model.as_str(), "gpt-5.4-mini");
     }
 
     #[test]
@@ -1734,7 +1647,7 @@ mod tests {
 
     #[test]
     fn request_builder_rejects_invalid_top_p() {
-        let err = GenerateTextRequest::builder(ModelRef::new("gpt-5.4-mini"))
+        let err = GenerateTextRequest::builder("gpt-5.4-mini")
             .message(Message::user_text("hello"))
             .top_p(1.1)
             .build()
@@ -1744,7 +1657,7 @@ mod tests {
 
     #[test]
     fn request_builder_rejects_invalid_temperature() {
-        let err = GenerateTextRequest::builder(ModelRef::new("gpt-5.4-mini"))
+        let err = GenerateTextRequest::builder("gpt-5.4-mini")
             .message(Message::user_text("hello"))
             .temperature(2.1)
             .build()
@@ -1754,7 +1667,7 @@ mod tests {
 
     #[test]
     fn request_builder_rejects_empty_messages() {
-        let err = GenerateTextRequest::builder(ModelRef::new("gpt-5.4-mini"))
+        let err = GenerateTextRequest::builder("gpt-5.4-mini")
             .build()
             .expect_err("empty messages should fail");
         assert!(err.message.contains("cannot be empty"));
@@ -1762,7 +1675,7 @@ mod tests {
 
     #[test]
     fn request_builder_accepts_messages_method() {
-        let req = GenerateTextRequest::builder(ModelRef::new("gpt-5.4-mini"))
+        let req = GenerateTextRequest::builder("gpt-5.4-mini")
             .messages(vec![Message::user_text("h1"), Message::user_text("h2")])
             .build()
             .expect("request should build");
@@ -1771,7 +1684,7 @@ mod tests {
 
     #[test]
     fn request_builder_user_prompt_replaces_messages() {
-        let req = GenerateTextRequest::builder(ModelRef::new("gpt-5.4-mini"))
+        let req = GenerateTextRequest::builder("gpt-5.4-mini")
             .message(Message::user_text("old"))
             .user_prompt("replaced")
             .build()
@@ -1781,7 +1694,7 @@ mod tests {
 
     #[test]
     fn request_builder_sets_all_fields() {
-        let req = GenerateTextRequest::builder(ModelRef::new("gpt-5.4-mini"))
+        let req = GenerateTextRequest::builder("gpt-5.4-mini")
             .message(Message::user_text("hi"))
             .temperature(0.7)
             .top_p(0.9)
@@ -1799,7 +1712,7 @@ mod tests {
 
     #[test]
     fn request_builder_empty_tools_is_none() {
-        let req = GenerateTextRequest::builder(ModelRef::new("gpt-5.4-mini"))
+        let req = GenerateTextRequest::builder("gpt-5.4-mini")
             .message(Message::user_text("hi"))
             .tools(Vec::<crate::tool::ToolDescriptor>::new())
             .build()
@@ -1809,7 +1722,7 @@ mod tests {
 
     #[test]
     fn request_builder_valid_temperature_boundary() {
-        let req = GenerateTextRequest::builder(ModelRef::new("gpt-5.4-mini"))
+        let req = GenerateTextRequest::builder("gpt-5.4-mini")
             .message(Message::user_text("hi"))
             .temperature(2.0)
             .top_p(0.0)
@@ -1859,7 +1772,7 @@ mod tests {
 
     #[test]
     fn run_tools_builds_with_valid_config() {
-        let rt = RunTools::new(ModelRef::new("gpt-5.5"))
+        let rt = RunTools::new("gpt-5.5")
             .messages([Message::user_text("hello")])
             .tools(Vec::<crate::tool::Tool>::new())
             .max_steps(5)
@@ -1876,7 +1789,7 @@ mod tests {
 
     #[test]
     fn run_tools_build_accepts_zero_max_steps_as_unlimited() {
-        let req = RunTools::new(ModelRef::new("gpt-5.5"))
+        let req = RunTools::new("gpt-5.5")
             .messages([Message::user_text("hello")])
             .max_steps(0)
             .build()
@@ -1886,7 +1799,7 @@ mod tests {
 
     #[test]
     fn run_tools_build_rejects_invalid_model() {
-        match RunTools::new(ModelRef::new("  "))
+        match RunTools::new("  ")
             .messages([Message::user_text("hello")])
             .build()
         {
@@ -1897,7 +1810,7 @@ mod tests {
 
     #[test]
     fn run_tools_default_max_steps_is_none() {
-        let rt = RunTools::new(ModelRef::new("gpt-5.5"))
+        let rt = RunTools::new("gpt-5.5")
             .messages([Message::user_text("hello")])
             .build()
             .expect("run tools should build");
@@ -1906,7 +1819,7 @@ mod tests {
 
     #[test]
     fn run_tools_default_tool_error_policy() {
-        let rt = RunTools::new(ModelRef::new("gpt-5.5"))
+        let rt = RunTools::new("gpt-5.5")
             .messages([Message::user_text("hello")])
             .build()
             .expect("run tools should build");

--- a/src/types.rs
+++ b/src/types.rs
@@ -1819,5 +1819,4 @@ mod tests {
             .expect("run tools should build");
         assert_eq!(rt.tool_error_policy, ToolErrorPolicy::ContinueAsToolResult);
     }
-
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,37 +18,6 @@ use serde_json::Value;
 use crate::error::{Error, ErrorCode};
 use crate::tool::{IntoTool, Tool, ToolDescriptor};
 
-/// Supported provider families.
-///
-/// This enum identifies the provider family for a given request or client configuration.
-/// It is used internally for routing requests to the correct adapter implementation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ProviderKind {
-    /// OpenAI provider family.
-    OpenAi,
-    /// Anthropic provider family.
-    Anthropic,
-    /// Google provider family.
-    Google,
-    /// OpenAI-compatible provider family (e.g., DeepSeek, local LLM servers).
-    OpenAiCompatible,
-}
-
-impl ProviderKind {
-    /// Returns the canonical provider slug.
-    ///
-    /// This method returns the normalized string identifier for the provider,
-    /// suitable for use in URLs, logging, or configuration.
-    pub fn as_slug(&self) -> &'static str {
-        match self {
-            Self::OpenAi => "openai",
-            Self::Anthropic => "anthropic",
-            Self::Google => "google",
-            Self::OpenAiCompatible => "openai-compatible",
-        }
-    }
-}
-
 /// Model reference: a provider-local model identifier string.
 ///
 /// # Example
@@ -1264,19 +1233,6 @@ mod tests {
         let original = ModelRef::new("gpt-5.5");
         let cloned = original.clone();
         assert_eq!(cloned.model(), "gpt-5.5");
-    }
-
-    // ─── ProviderKind ────────────────────────────────────────────────────
-
-    #[test]
-    fn provider_kind_as_slug() {
-        assert_eq!(ProviderKind::OpenAi.as_slug(), "openai");
-        assert_eq!(ProviderKind::Anthropic.as_slug(), "anthropic");
-        assert_eq!(ProviderKind::Google.as_slug(), "google");
-        assert_eq!(
-            ProviderKind::OpenAiCompatible.as_slug(),
-            "openai-compatible"
-        );
     }
 
     // ─── Message validation ──────────────────────────────────────────────

--- a/tests/client_builder.rs
+++ b/tests/client_builder.rs
@@ -1,7 +1,4 @@
-use aquaregia::{
-    AnthropicAdapterSettings, ErrorCode, GoogleAdapterSettings, LlmClient, OpenAiAdapterSettings,
-    OpenAiCompatibleAdapterSettings,
-};
+use aquaregia::{ErrorCode, LlmClient};
 use std::time::Duration;
 
 // ─── OpenAI client builder ──────────────────────────────────────────────
@@ -106,46 +103,6 @@ fn openai_compatible_rejects_empty_base_url() {
         Err(err) => assert_eq!(err.code, ErrorCode::InvalidRequest),
         Ok(_) => panic!("empty base url should fail"),
     }
-}
-
-// ─── OpenAiCompatibleAdapterSettings ────────────────────────────────────
-
-#[test]
-fn compatible_settings_new_has_defaults() {
-    let mut s = OpenAiCompatibleAdapterSettings::new();
-    s.base_url = "https://api.example.com".to_string();
-    assert_eq!(s.base_url, "https://api.example.com");
-}
-
-// ─── Provider adapter settings constructors ─────────────────────────────
-
-#[test]
-fn openai_settings_default_base_url() {
-    let mut settings = OpenAiAdapterSettings::new();
-    settings.api_key = "sk-key".to_string();
-    assert!(settings.base_url.contains("api.openai.com"));
-    assert_eq!(settings.api_key, "sk-key");
-}
-
-#[test]
-fn anthropic_settings_default_values() {
-    let mut settings = AnthropicAdapterSettings::new();
-    settings.api_key = "sk-ant-key".to_string();
-    assert!(settings.base_url.contains("api.anthropic.com"));
-    assert_eq!(settings.api_key, "sk-ant-key");
-    assert!(settings.api_version.contains("2023-06-01"));
-}
-
-#[test]
-fn google_settings_default_base_url() {
-    let mut settings = GoogleAdapterSettings::new();
-    settings.api_key = "g-key".to_string();
-    assert!(
-        settings
-            .base_url
-            .contains("generativelanguage.googleapis.com")
-    );
-    assert_eq!(settings.api_key, "g-key");
 }
 
 // ─── ClientBuilder default_max_steps: 0 means unlimited, no upper cap ───


### PR DESCRIPTION
## Summary

Eighteen commits accumulated on `dev` since the last sync. Grouped by theme:

- **Structured output** — `generate_object::<T>()` with `schemars`-derived JSON Schema, plus a streaming `ObjectStream` event surface. OpenAI uses native response_format; Anthropic and Google use a tool-use fallback.
- **partial_json hardening** — rewrite the JSON-repair pass as a stack-based state machine; harden against unicode escape truncation; accept root-level arrays. Deferred follow-ups tracked in #37.
- **Model identifier refresh** — replace deprecated model IDs across examples and docs (e.g. `claude-3-5-haiku-latest` → `claude-haiku-4-5`).
- **API cleanup pass** (6 commits, `b5fd790`…`3e19d1f`, driven by external review):
  - Remove the unused `ProviderKind` enum
  - Replace the handrolled base64 encoder with the `base64` crate (no new compile unit — same 0.22.1 version already pulled in transitively by `reqwest`)
  - Drop the `ModelRef` newtype; use `String` directly (the wrapper added no validation and violated our own AGENTS.md §7)
  - Seal the `BuildProvider` trait so external crates cannot impl it (replaces `#[doc(hidden)] pub`)
  - Collapse the `Agent` / `AgentBuilder` / `RunTools` 18-field mirror; adding a new hook now touches three sites instead of eight (−130 lines in `agent.rs`)
  - Drop four `tests/client_builder.rs` settings-defaults tests that exercised no behavior contract (per `tests/CLAUDE.md` §9)
- **Documentation** — sync the structured-output section into the Chinese README; drop internal implementation details from both READMEs.

Net diff: **+2482 / −644 across 37 files**. Every commit is independent and bisectable.

The long-term plan for further public API surface reduction (currently 49 root-level re-exports) is tracked in #39.

## Test plan

- [x] `cargo build`
- [x] `cargo build --examples`
- [x] `cargo test` — 218 unit tests, 11 doctests, all integration suites green
- [x] `cargo clippy --all-targets` — no new warnings introduced by this branch