### PR TITLE
docs: refine AGENTS.md core principles from this session's lessons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Before implementing:
 
 - State your assumptions explicitly. If uncertain, ask.
 - If multiple interpretations exist, present them - don't pick silently.
-- If a simpler approach exists, say so. Push back when warranted.
+- If a simpler approach exists, or the user's framing seems wrong, say so before implementing. Silent compliance is the failure mode, not delay.
 - If something is unclear, stop. Name what's confusing. Ask.
 
 ## 2. Simplicity First
@@ -24,6 +24,7 @@ Before implementing:
 - No "flexibility" or "configurability" that wasn't requested.
 - No error handling for impossible scenarios.
 - If you write 200 lines and it could be 50, rewrite it.
+- Public exposure is part of complexity. A `pub` type, re-export, or trait method joins the API contract — every name there is a future breaking-change target. Default to `pub(crate)`; promote to `pub` only when an external caller genuinely needs it. Mirror data structures, `#[doc(hidden)] pub` trait surfaces, and dead re-exports all qualify as complexity that wasn't asked for.
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
@@ -43,7 +44,7 @@ When your changes create orphans:
 - Remove imports/variables/functions that YOUR changes made unused.
 - Don't remove pre-existing dead code unless asked.
 
-The test: Every changed line should trace directly to the user's request.
+The test: Every changed line traces directly to the user's request — file count and fan-out don't matter, traceability does.
 
 ## 4. Goal-Driven Execution
 
@@ -55,7 +56,7 @@ Transform tasks into verifiable goals:
 - "Fix the bug" → "Write a test that reproduces it, then make it pass"
 - "Refactor X" → "Ensure tests pass before and after"
 
-For multi-step tasks, state a brief plan:
+For multi-step tasks where each step depends on the previous one, state a brief plan:
 
 ```
 1. [Step] → verify: [check]
@@ -65,27 +66,31 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
-## 5. Use AI Responsibly
+"Tests pass" usually means more than `cargo test`. If CI gates on `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`, those are part of the success criterion — a green local test run that ships a clippy warning still fails the gate. Treat the full CI check set as the verification step, not the subset you happen to run locally.
 
-**AI is allowed. Judgment is not outsourced.**
+## 5. Honest Reporting
 
-- AI assistance is allowed and encouraged for exploration, drafting, and implementation.
-- The person or agent making the change must still understand what changed, why it changed, and how it was validated.
-- Do not ship code, tests, or documentation that you cannot explain, review, or debug.
-- Use AI to accelerate execution, not to replace engineering judgment.
+**The user can't verify every step. Your reports must be honest enough that they could.**
+
+- Don't claim a check you didn't run. If you verified A but skipped B, name B — don't let "all checks pass" paper over the gap.
+- Surface uncertainty you didn't resolve. If a number was estimated, mark it estimated; if a search may have missed cases, say where.
+- Flag scope you expanded without asking. If the request was "fix X" and you also touched Y, name Y in the report — don't bury it in the diff.
+- Name judgment calls the user delegated to you. "You decide" is not a license to decide silently — surface the call you made so the user can override.
+
+The test: if the user audits your work an hour later, will they find anything you didn't already mention?
 
 ## 6. Write Durable Guidance, Not Checklists
 
 **Agent-facing documentation should age slowly.**
 
-- Files such as `AGENTS.md` and `CLAUDE.md` should capture stable principles, constraints, and decision rules.
+- Files such as `AGENTS.md` and `CLAUDE.md` should capture stable principles. Prefer revising an existing principle over adding a new one — readers run out of working memory before reaching the bottom.
 - Avoid long inventories of internal APIs, file lists, or implementation-specific checklists that will drift from the code.
 - Prefer guidance that explains how to reason about the system over guidance that attempts to mirror the system exhaustively.
 - If examples are needed, keep them short and illustrative rather than comprehensive.
 
 ## 7. Lean API Design
 
-**Type-level machinery must earn its complexity.**
+**Every abstraction — public or internal — must earn its complexity.**
 
 Every generic parameter, marker trait, phantom type, or feature flag that ends up in user-facing code costs the user cognitive overhead every time they write a type annotation or read an error message. Add that cost only when there is a concrete, demonstrable benefit.
 
@@ -103,8 +108,11 @@ Concrete rules for this codebase:
 - No feature flags that gate no code (`openai = []` is noise, not a feature).
 - No trait hierarchies where each implementor does something entirely different — four `impl`s with no shared runtime behaviour is not polymorphism, it is a dispatch table in disguise.
 - No extra wrapper types when a plain value type (`String`, a struct with named fields) communicates the same contract.
+- A trait with few methods is not under-designed when the per-implementation work is supposed to be encapsulated. Don't expand a trait's surface to "advertise" the diversity its implementations hide — that diversity belongs inside the implementors. A multi-provider adapter trait with two methods is correct precisely because provider differences are not part of the shared contract.
 
 The test: if removing the abstraction requires no user-side code changes beyond dropping a type annotation, it was not carrying its weight.
+
+Corollary: when an abstraction has to stay because it appears in a public bound, pick the access modifier that matches your intent. `#[doc(hidden)] pub trait` hides from rustdoc but does not prevent external impls — that is documentation theater. Use the sealed-trait pattern (`pub trait T: private::Sealed`) when you need a public bound without a public extension point.
 
 ---
 


### PR DESCRIPTION
External code review surfaced gaps in the existing agent guidance. Patch the principles rather than adding new ones:

§1: harden "push back when warranted" — silent compliance with a flawed framing is the failure mode, not delay.
§2: add public-exposure-is-complexity bullet (covers dead re-exports, mirror structures, doc(hidden) pub).
§3: tighten the surgical test — it's about traceability, not file count or fan-out.
§4: scope the plan template to dependent steps; extend success criteria to include CI checks beyond `cargo test`. §5: replace "Use AI Responsibly" (written for humans choosing to adopt AI) with "Honest Reporting" (written for agents whose work the user can't audit line-by-line).
§6: bake "prefer revising existing principles over adding new ones" into the rule itself.
§7: broaden from "type-level machinery" to "every abstraction — public or internal"; add that few-method traits aren't under-designed when per-implementation work is encapsulated; add a sealed-trait corollary for traits that must be `pub` for a public bound but shouldn't be implementable downstream.