### PR TITLE
v0.2.0: structured streaming, lean API surface, README rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,3 @@ jobs:
 
       - name: Check without default features
         run: cargo check --locked --no-default-features
-
-      - name: Check telemetry feature set
-        run: cargo check --locked --features telemetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While the crate is `0.y.z`, minor version bumps may introduce breaking changes.
+
+## [0.2.0] — 2026-05-28
+
+### Added
+
+- **Structured streaming output**: `BoundClient::stream_object::<T>()` emits `StreamObjectEvent::Partial { partial }` as new fields arrive and a final `StreamObjectEvent::Object { object }` when the stream completes. Backed by a stack-based partial JSON repairer that handles truncated strings, unclosed arrays/objects, and escape sequences mid-token.
+- **Structured (non-streaming) output**: `BoundClient::generate_object::<T>()` returns a typed `GenerateObjectResponse<T>`. Schema is derived from `T: schemars::JsonSchema`. Providers without native structured-output mode (Anthropic, Google) fall back transparently to forced tool calls.
+- New example: `examples/structured_streaming.rs`.
+
+### Changed (breaking)
+
+- **Model reference is now `String`** (was `ModelRef` newtype). Pass any `impl Into<String>` to `GenerateTextRequest::from_user_prompt` / `::builder` / `Agent::builder`.
+- **`BuildProvider` is now sealed** via `pub trait BuildProvider: private::Sealed`. External adapters belong in the `model_adapters` module rather than as downstream `impl`s.
+- **`telemetry` feature flag removed**, and with it the optional `tracing` dependency. The flag previously gated no code.
+- **`ProviderKind` enum removed** (was unused).
+- **`ModelRef` newtype removed** (use `String` directly).
+
+### Changed (non-breaking)
+
+- `Agent` / `AgentBuilder` / `RunTools` field mirror collapsed — internal restructuring; user-facing builder API unchanged.
+- Base64 encoding switched from a hand-rolled implementation to the `base64` crate.
+- `#[doc(hidden)]` annotations on `BuildProvider` methods removed (the trait is sealed; the hidden marker was redundant).
+- Default Claude model identifier in tests and examples bumped to `claude-haiku-4-5`.
+
+### Fixed
+
+- `partial_json` repair: rewritten as a stack-based state machine; hardened against unicode escape truncation; root arrays supported.
+- `stream_object` schema injection deduplicated; `type_name` sanitised; final buffer flushed on EOF.
+- `cargo doc` no longer warns about broken intra-doc links to the (private) `ToolRegistry`.
+
+### Docs
+
+- README.md and README_CN.md fully rewritten with an onboarding-flow narrative (Introduction → Quick Start → Essentials → Production → Integration → Reference), retaining all reference tables.
+- `examples/README.md`: removed phantom `google_generate.rs` reference; added `structured_streaming.rs` to the list.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aquaregia"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
- "tracing",
  "wiremock",
 ]
 
@@ -1223,19 +1222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aquaregia"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2024"
 description = "A single crate for building LLM-powered applications and agents across any provider."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,6 @@ exclude = [
 name = "aquaregia"
 path = "src/lib.rs"
 
-[features]
-telemetry = ["dep:tracing"]
-
 [dependencies]
 
 async-stream = "0.3"
@@ -45,7 +42,6 @@ serde_json = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.44", features = ["macros", "rt-multi-thread", "time"] }
 tokio-util = { version = "0.7" }
-tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 http = "1"

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ let client = LlmClient::openai().api_key(std::env::var("OPENAI_API_KEY")?)
 
 ### Model references
 
-`GenerateTextRequest::from_user_prompt` and `.builder()` accept any `impl Into<ModelRef>` — a bare `&str` is the most common form:
+`GenerateTextRequest::from_user_prompt` and `.builder()` accept any `impl Into<String>` — a bare `&str` is the most common form:
 
 ```rust
 let req = GenerateTextRequest::from_user_prompt("gpt-5.5", "Hello!");

--- a/README.md
+++ b/README.md
@@ -13,18 +13,57 @@
 
 </div>
 
-A single crate for building LLM-powered applications and agents across any provider.
+---
+
+## Introduction
+
+### Why Aquaregia
+
+You want to call an LLM from Rust. You probably also want to call _another_ LLM from Rust six months from now, without rewriting your prompts, your tool definitions, or your streaming code.
+
+Aquaregia is a single crate that gives you one API across OpenAI, Anthropic, Google, and any OpenAI-compatible endpoint. You swap a constructor and the same `generate`, `stream`, `generate_object`, and `Agent` calls keep working. Streaming, structured output, reasoning tokens, multimodal input, agent loops, retries, cancellation — all of it normalised behind one type.
+
+It's not a gateway, not a proxy, not a microservice. It's a Rust library you `cargo add` and call directly.
+
+### At a glance
+
+| Capability                        | What you get                                                                            |
+| --------------------------------- | --------------------------------------------------------------------------------------- |
+| **One API, four providers**       | OpenAI · Anthropic · Google · OpenAI-compatible (DeepSeek, Together, Groq, …)            |
+| **Streaming & non-streaming**     | Same builder feeds `generate` or `stream`, with consistent `StreamEvent`s                |
+| **Structured output**             | `generate_object::<T>()` and `stream_object::<T>()` with `schemars`-derived schemas      |
+| **Reasoning content**             | First-class reasoning extraction, streaming reasoning deltas, reasoning-token usage      |
+| **Tool-using agents**             | Multi-step loop with `prepare_step` hooks, `max_steps`, `stop_when`, error policies      |
+| **Multimodal vision**             | Send images by URL, base64, or raw bytes — one `ImagePart` API across providers          |
+| **Cancellation & retries**        | `CancellationToken` checked everywhere; exponential backoff with `Retry-After` honored   |
+
+### When not to use it
+
+If you only ever target one provider and don't care about being portable, that provider's native SDK probably gives you a more idiomatic surface. Aquaregia earns its keep when you want to **A/B providers**, **let users pick a model at runtime**, or **future-proof against the LLM landscape moving under you**. If none of those apply, you're not the target audience — and that's fine.
 
 ---
 
-## Quick start
+## Quick Start
+
+### Install
+
+```bash
+cargo add aquaregia
+```
+
+You'll also need a Tokio runtime in your application — Aquaregia is async end-to-end.
+
+### Hello world
+
+The shortest path to a real model response:
 
 ```rust
 use aquaregia::{GenerateTextRequest, LlmClient};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = LlmClient::openai_compatible().base_url("https://api.deepseek.com")
+    let client = LlmClient::openai_compatible()
+        .base_url("https://api.deepseek.com")
         .api_key(std::env::var("DEEPSEEK_API_KEY")?)
         .build()?;
 
@@ -36,88 +75,89 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     println!("{}", response.output_text);
-    println!(
-        "usage: {} → {} tokens",
-        response.usage.input_tokens, response.usage.output_tokens
-    );
     Ok(())
 }
 ```
 
-Swap the constructor and the same call works against Anthropic, OpenAI, or Google.
+Three moving parts: a **client** (provider + auth + transport), a **request** (model + messages), and a `.generate()` call. Everything in this guide is a refinement of one of those three.
 
----
+### First streaming call
 
-## Installation
+Same client, swap `.generate` for `.stream`:
 
-```bash
-cargo add aquaregia
+```rust
+use aquaregia::StreamEvent;
+use futures_util::StreamExt;
+
+let mut stream = client
+    .stream(GenerateTextRequest::from_user_prompt(
+        "deepseek-v4-pro",
+        "Write a haiku about the borrow checker.",
+    ))
+    .await?;
+
+while let Some(event) = stream.next().await {
+    match event? {
+        StreamEvent::TextDelta { text } => print!("{text}"),
+        StreamEvent::Done               => break,
+        _                                => {}
+    }
+}
 ```
 
-You also need a Tokio runtime in your project.
+You've now seen the shape — a builder, a call, a result or an event loop. The rest of this guide unpacks each piece.
 
 ---
 
-## Providers
+## Essentials
 
-Pick a constructor to get a `BoundClient` for that provider.
+### Client
 
-| Provider          | Constructor                                              | Model argument        |
-| ----------------- | -------------------------------------------------------- | --------------------- |
-| OpenAI            | `LlmClient::openai().api_key(api_key)`                             | `"gpt-5.5"`            |
-| Anthropic         | `LlmClient::anthropic().api_key(api_key)`                          | `"claude-sonnet-4-6"` |
-| Google            | `LlmClient::google().api_key(api_key)`                             | `"gemini-3.5-flash"`  |
-| OpenAI-compatible | `LlmClient::openai_compatible().base_url(base_url).api_key(...)`    | `"deepseek-v4-pro"`     |
-
-### Client configuration
+A `LlmClient` is just a namespace of constructors. Each constructor returns a typed `ClientBuilder<S>` parameterised on the provider's settings type, which builds into a reusable `BoundClient`. Think **constructor → builder → bound client** — that's the whole shape, and it's the same regardless of which provider you pick.
 
 ```rust
 use std::time::Duration;
 
-let client = LlmClient::openai().api_key(std::env::var("OPENAI_API_KEY")?)
-    .base_url("https://api.openai.com")          // custom upstream
-    .timeout(Duration::from_secs(60))            // per-request timeout
+let client = LlmClient::openai()
+    .api_key(std::env::var("OPENAI_API_KEY")?)
+    .base_url("https://api.openai.com")          // optional: custom upstream
+    .timeout(Duration::from_secs(60))            // per-request HTTP timeout
     .max_retries(3)                              // transient-failure retries
-    .default_max_steps(8)                        // default for Agents built from this client
+    .default_max_steps(8)                        // default agent step cap
     .user_agent("my-app/1.0")
     .build()?;
 ```
 
-### Model references
+Switching providers is just a different constructor — every method you'll see below works the same way on whichever `BoundClient` you end up with.
 
-`GenerateTextRequest::from_user_prompt` and `.builder()` accept any `impl Into<String>` — a bare `&str` is the most common form:
+| Provider          | Constructor                                                         |
+| ----------------- | ------------------------------------------------------------------- |
+| OpenAI            | `LlmClient::openai().api_key(api_key)`                              |
+| Anthropic         | `LlmClient::anthropic().api_key(api_key).api_version("2023-06-01")` |
+| Google            | `LlmClient::google().api_key(api_key)`                              |
+| OpenAI-compatible | `LlmClient::openai_compatible().base_url(url).api_key(token)`       |
+
+#### Going deeper: OpenAI-compatible endpoints
+
+If your provider speaks the OpenAI chat-completions wire format but lives at a different URL — DeepSeek, Together, Groq, your own gateway — `openai_compatible()` lets you bolt on custom headers, query params, and even a different chat path:
 
 ```rust
-let req = GenerateTextRequest::from_user_prompt("gpt-5.5", "Hello!");
-```
-
-### OpenAI-compatible deep configuration
-
-```rust
-let client = LlmClient::openai_compatible().base_url("https://api.deepseek.com")
+let client = LlmClient::openai_compatible()
+    .base_url("https://api.deepseek.com")
     .api_key(std::env::var("DEEPSEEK_API_KEY")?)
     .header("x-trace-source", "aquaregia")
     .query_param("source", "sdk")
-    .chat_completions_path("/v1/chat/completions") // override the endpoint path
+    .chat_completions_path("/v1/chat/completions")
     .build()?;
 ```
 
-### Provider differences at a glance
-
-| Capability                       | OpenAI | Anthropic | Google | OpenAI-Compatible |
-| -------------------------------- | :----: | :-------: | :----: | :---------------: |
-| Custom `base_url`                |   ✓    |     ✓     |   ✓    |         ✓         |
-| Custom headers / query / path    |        |           |        |         ✓         |
-| `api_version` (header)           |        |     ✓     |        |                   |
-| Structured output                |   ✓    |     ✓     |   ✓    |         ✓         |
-| Tool-call streaming              |   ✓    |     ✓     |   ✓    |         ✓         |
-| Cache-token split in `Usage`     |   ✓    |     ✓     |   ✓    |   if reported     |
+If the endpoint doesn't want any `Authorization` header at all, call `.no_api_key()` instead of `.api_key(...)`.
 
 ---
 
-## Generating text
+### Generating text
 
-### One-shot `generate`
+`generate` is the workhorse: one request, one response, all content in `output_text`.
 
 ```rust
 let response = client
@@ -131,7 +171,7 @@ println!("{}", response.output_text);
 println!("finish: {:?}", response.finish_reason);
 ```
 
-Full builder when you need messages, sampling, or tools:
+`from_user_prompt(model, prompt)` is the one-line form. When you need more — system prompts, sampling controls, tools — reach for the builder:
 
 ```rust
 use aquaregia::{GenerateTextRequest, Message};
@@ -144,13 +184,20 @@ let req = GenerateTextRequest::builder("deepseek-v4-pro")
     .build()?;
 ```
 
-### Streaming
+The model argument is just a string — Aquaregia doesn't try to enumerate model IDs because every provider ships new ones every few weeks. Pass whatever your provider's docs say is current; if the provider rejects it, you'll get a clean `InvalidRequest` error back.
+
+---
+
+### Streaming responses
+
+When the consumer is a UI or a terminal, you want tokens as they arrive, not after the whole reply lands. Swap `generate` for `stream` and consume `StreamEvent`s:
 
 ```rust
 use aquaregia::StreamEvent;
 use futures_util::StreamExt;
 
 let mut stream = client.stream(request).await?;
+
 while let Some(event) = stream.next().await {
     match event? {
         StreamEvent::TextDelta { text }          => print!("{text}"),
@@ -166,21 +213,25 @@ while let Some(event) = stream.next().await {
 }
 ```
 
-All variants:
+The event stream is the union of everything a model might emit. You'll typically only match a few variants; the rest you can `_ => {}`. Here's the full menu:
 
-| Event                | Fields                                  |
-| -------------------- | --------------------------------------- |
-| `ReasoningStarted`   | `block_id`, `provider_metadata`         |
-| `ReasoningDelta`     | `block_id`, `text`, `provider_metadata` |
-| `ReasoningDone`      | `block_id`, `provider_metadata`         |
-| `TextDelta`          | `text`                                  |
-| `ToolCallReady`      | `call: ToolCall`                        |
-| `Usage`              | `usage: Usage`                          |
-| `Done`               | —                                       |
+| Event                | Fields                                  | When it fires                                  |
+| -------------------- | --------------------------------------- | ---------------------------------------------- |
+| `ReasoningStarted`   | `block_id`, `provider_metadata`         | A reasoning block begins (Anthropic / Google)  |
+| `ReasoningDelta`     | `block_id`, `text`, `provider_metadata` | Each token of thought                          |
+| `ReasoningDone`      | `block_id`, `provider_metadata`         | A reasoning block closed                       |
+| `TextDelta`          | `text`                                  | Each token of the visible answer               |
+| `ToolCallReady`      | `call: ToolCall`                        | Model finished assembling a tool call          |
+| `Usage`              | `usage: Usage`                          | Provider reports token counts                  |
+| `Done`               | —                                       | Final event of every stream                    |
+
+Once `Done` fires the stream is finished — don't poll after.
+
+---
 
 ### Reasoning
 
-Reasoning is exposed in both sync and streaming output:
+Reasoning is the model's "thinking out loud" — separate from the visible answer, exposed as its own content block by Anthropic Extended Thinking, Google's `thoughts`, and OpenAI's reasoning-token accounting. Aquaregia surfaces it uniformly:
 
 ```rust
 let out = client.generate(req).await?;
@@ -191,43 +242,29 @@ println!("rsn-tokens: {}", out.usage.reasoning_tokens);
 
 for part in &out.reasoning_parts {
     println!("[block] {}", part.text);
-    // part.provider_metadata carries signature blocks (Anthropic), thought
-    // signatures (Google), and provider-specific extras.
+    // part.provider_metadata carries signature blocks (Anthropic),
+    // thought signatures (Google), and any other provider extras.
 }
 ```
 
-| Provider   | Usage mapping                                                                                       |
-| ---------- | --------------------------------------------------------------------------------------------------- |
-| OpenAI / OpenAI-compatible | parses `prompt_tokens_details.cached_tokens` + `completion_tokens_details.reasoning_tokens` |
-| Anthropic  | parses `cache_read_input_tokens` / `cache_creation_input_tokens`; reasoning split unavailable       |
-| Google     | parses `cachedContentTokenCount` + `thoughtsTokenCount`                                             |
+In streaming you'll see `ReasoningStarted` → `ReasoningDelta`(s) → `ReasoningDone` for each reasoning block before the visible text starts. The token-usage split comes from whichever fields the provider populates:
 
-### `Usage` and aggregation
+| Provider                   | Reasoning-token mapping                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------------------- |
+| OpenAI / OpenAI-compatible | `prompt_tokens_details.cached_tokens` + `completion_tokens_details.reasoning_tokens`        |
+| Anthropic                  | `cache_read_input_tokens` / `cache_creation_input_tokens`; reasoning-token split unavailable |
+| Google                     | `cachedContentTokenCount` + `thoughtsTokenCount`                                            |
 
-```rust
-pub struct Usage {
-    pub input_tokens:             u32, // total
-    pub input_no_cache_tokens:    u32,
-    pub input_cache_read_tokens:  u32,
-    pub input_cache_write_tokens: u32,
-    pub output_tokens:            u32, // total
-    pub output_text_tokens:       u32,
-    pub reasoning_tokens:         u32,
-    pub total_tokens:             u32,
-    pub raw_usage:                Option<serde_json::Value>,
-}
-```
-
-`Usage` implements `Add` and `AddAssign`, so totaling tokens across agent steps is a one-liner. `AgentResponse.usage_total` is already aggregated for you.
+If a provider doesn't report a number, the field stays at `0` — Aquaregia never makes up data.
 
 ---
 
-## Structured output
+### Structured output
 
-Call `generate_object::<T>()` to get a Rust type back — no manual JSON parsing required. The JSON Schema is derived automatically from your type via `schemars`.
+When you want a typed Rust value back instead of a blob of text, derive `JsonSchema` and call `generate_object::<T>()`. The schema is generated automatically and passed to the provider; the JSON response is parsed straight into `T`.
 
 ```rust
-use aquaregia::{GenerateTextRequest, LlmClient};
+use aquaregia::{GenerateTextRequest, LlmClient, Message};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -237,34 +274,57 @@ struct WeatherResult {
     temp_c: f64,
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = LlmClient::openai().api_key(std::env::var("OPENAI_API_KEY")?).build()?;
+let req = GenerateTextRequest::builder("gpt-5.5")
+    .message(Message::user_text("What is the weather in Tokyo?"))
+    .temperature(0.2)
+    .build()?;
 
-    let req = GenerateTextRequest::builder("gpt-5.5")
-        .message(Message::user_text("What is the weather in Tokyo?"))
-        .temperature(0.2)
-        .build()?;
+let result = client.generate_object::<WeatherResult>(req).await?;
 
-    let result = client.generate_object::<WeatherResult>(req).await?;
+println!("{} → {}°C", result.object.city, result.object.temp_c);
+```
 
-    println!("City: {}, Temp: {}°C", result.object.city, result.object.temp_c);
-    println!("tokens: {} in / {} out", result.usage.input_tokens, result.usage.output_tokens);
-    Ok(())
+Providers without native structured-output mode (Anthropic, Google) fall back transparently to forced tool calls. From the caller's perspective there's no difference — you get a `T` either way.
+
+#### Streaming partial objects
+
+For UIs that should render fields as they arrive, `stream_object::<T>()` emits progressively-populated values. Each chunk is repaired and re-deserialised into a partial `T`. Fields not yet emitted by the model stay at their `Default`, so derive `Default` and add `#[serde(default)]`:
+
+```rust
+use aquaregia::{GenerateTextRequest, LlmClient, Message, StreamObjectEvent};
+use futures_util::StreamExt;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(default)]
+struct WeatherResult {
+    city:   String,
+    temp_c: f64,
+}
+
+let mut stream = client.stream_object::<WeatherResult>(req).await?;
+while let Some(event) = stream.next().await {
+    match event? {
+        StreamObjectEvent::Partial { partial } => {
+            println!("partial: {} ({}°C)", partial.city, partial.temp_c);
+        }
+        StreamObjectEvent::Object { object } => {
+            println!("final:   {:?}", object);
+        }
+    }
 }
 ```
 
-All providers produce the same typed output — the extraction strategy is transparent to the caller.
+Under the hood is a stack-based JSON repairer that handles truncated strings, unclosed arrays and objects, and escape sequences mid-token. A chunk that splits a field name or value still produces a valid partial — you never have to handle invalid JSON in your code. See `examples/structured_streaming.rs` for a runnable version.
 
 ---
 
-## Tools & Agents
+### Tools
 
-### Defining tools
+A tool lets the model call your Rust code mid-conversation. Think of one as a **typed `async fn` the LLM can invoke by name** — Aquaregia builds the JSON Schema from your argument type, marshals the call args back into Rust, and runs your function.
 
-Tools are built with the `tool(name)` function. Two execution styles are supported.
-
-**Typed args** — `schemars` derives the JSON Schema from your struct:
+The typed style is the one you'll reach for most:
 
 ```rust
 use aquaregia::{Tool, tool};
@@ -284,7 +344,9 @@ fn get_weather() -> Tool {
 }
 ```
 
-**Raw schema** — write the JSON Schema by hand, receive a `serde_json::Value`:
+`tool(name)` starts a builder; `.execute(closure)` consumes a `JsonSchema`-derived arg type and finishes the build. The closure returns `Result<serde_json::Value, ToolExecError>` — the model gets back whatever JSON you produce.
+
+If you'd rather hand-write the schema (unusual constraints, no derive available), use `.raw_schema(...)` + `.execute_raw(...)`:
 
 ```rust
 let fx_tool = tool("get_fx_rate")
@@ -300,14 +362,21 @@ let fx_tool = tool("get_fx_rate")
     });
 ```
 
-Tool names must match `^[a-zA-Z0-9_-]{1,64}$` and be unique within an agent.
+Tool names must match `^[a-zA-Z0-9_-]{1,64}$` and be unique within an agent. That's validated at agent build time so an invalid registry never reaches the model.
 
-### Minimal Agent
+---
+
+### Agents
+
+An `Agent` is a `generate`-plus-tools `while` loop with hooks: the model thinks → maybe calls tools → you run the tools → results go back to the model → repeat until it stops calling tools (or you cap it). You don't write the loop; you describe its inputs and outputs.
+
+The minimum agent is one tool and a step cap:
 
 ```rust
 use aquaregia::{Agent, LlmClient};
 
-let client = LlmClient::openai_compatible().base_url("https://api.deepseek.com")
+let client = LlmClient::openai_compatible()
+    .base_url("https://api.deepseek.com")
     .api_key(std::env::var("DEEPSEEK_API_KEY")?)
     .build()?;
 
@@ -322,9 +391,11 @@ println!("{}", response.output_text);
 println!("steps={} total={}", response.steps, response.usage_total.total_tokens);
 ```
 
-### Event hooks
+`response.output_text` is the final user-visible answer. `response.steps` tells you how many round-trips it took; `response.usage_total` aggregates token counts across every call.
 
-The agent loop emits an event at every meaningful boundary. All hooks are `Fn + Send + Sync`, so you can attach them as closures.
+#### Event hooks
+
+Every interesting boundary in the loop emits an event. All hooks are `Fn + Send + Sync`, so you can attach closures directly — useful for logging, metrics, debug UIs:
 
 ```rust
 let agent = Agent::builder(client, "deepseek-v4-pro")
@@ -338,9 +409,9 @@ let agent = Agent::builder(client, "deepseek-v4-pro")
     .build()?;
 ```
 
-### Dynamic planning — `prepare_step`
+#### Dynamic planning with `prepare_step`
 
-`prepare_step` runs before every step and returns a fresh prepared plan — useful for shrinking the tool set, switching models, or injecting per-step instructions:
+When you need to mutate the next step before it runs — narrow the tool list, swap models, inject a system prompt for that step only — give the agent a `prepare_step` closure:
 
 ```rust
 use aquaregia::Message;
@@ -360,27 +431,31 @@ let agent = Agent::builder(client, "deepseek-v4-pro")
     .build()?;
 ```
 
-### Stopping policies
+The returned `AgentPreparedStep` is what the agent actually sends to the model for this step. Anything you don't change carries over from the previous state.
+
+#### Stopping policies
+
+Three knobs control how the loop ends:
 
 ```rust
 use aquaregia::ToolErrorPolicy;
 
 let agent = Agent::builder(client, "deepseek-v4-pro")
-    .max_steps(8)                                                                 // hard cap
-    .stop_when(|step| step.tool_calls.is_empty() && !step.output_text.is_empty()) // predicate
-    .tool_error_policy(ToolErrorPolicy::ContinueAsToolResult)                     // default
+    .max_steps(8)
+    .stop_when(|step| step.tool_calls.is_empty() && !step.output_text.is_empty())
+    .tool_error_policy(ToolErrorPolicy::ContinueAsToolResult)
     .build()?;
 ```
 
-- `max_steps` — exceeding it returns `ErrorCode::MaxStepsExceeded`.
-- `stop_when` — predicate evaluated after every step; truthy = stop early.
-- `tool_error_policy` —
-  - `ContinueAsToolResult` (default) — schema-validation failures, timeouts, and panics become `{ "error": "..." }` tool results so the model can recover.
+- **`max_steps`** — hard cap. Hitting it returns `ErrorCode::MaxStepsExceeded` instead of silently truncating.
+- **`stop_when`** — predicate checked after every step. Useful when you have a sharper definition of "done" than "no more tool calls".
+- **`tool_error_policy`** — what happens when a tool throws.
+  - `ContinueAsToolResult` (default) — schema-validation failures, timeouts, and panics become `{ "error": "..." }` results so the model can recover on the next step.
   - `FailFast` — surface as `ErrorCode::ToolExecutionFailed` / `InvalidToolArgs` immediately.
 
-### Multi-turn conversations
+#### Multi-turn conversations
 
-`AgentResponse.transcript` is a complete `Vec<Message>` (system + user + assistant + tool results) that you can feed straight back into the next turn:
+`AgentResponse.transcript` is a complete `Vec<Message>` (system + user + assistant + tool results) you can feed straight back in for the next turn — no manual reconstruction:
 
 ```rust
 let mut history = vec![Message::system_text("You are a careful assistant.")];
@@ -400,7 +475,11 @@ See `examples/mini_claude_code.rs` for a working terminal agent that uses this p
 
 ---
 
-## Multimodal vision
+### Multimodal
+
+Vision models take images alongside text. Aquaregia hides the per-provider differences behind one `ImagePart` type — you say "URL" or "bytes" once, and the right thing happens on the wire.
+
+The shortest path is `Message::user_image_url` or `Message::user_image_bytes`. For mixed content or multiple images per message, build a `Message` with explicit content parts:
 
 ```rust
 use aquaregia::{
@@ -430,16 +509,16 @@ let out = client
     .await?;
 ```
 
-Two convenience constructors plus a full-control form:
+The convenience constructors:
 
 | Constructor                                                              | Use case                                  |
 | ------------------------------------------------------------------------ | ----------------------------------------- |
-| `Message::user_image_url(url)`                                           | Single image from a URL                   |
-| `Message::user_image_bytes(bytes, mime)`                                 | Single image from raw bytes (auto base64) |
-| `Message::new(MessageRole::User, vec![Text, Image, …])`                  | Mixed content (text + image, multi-image) |
+| `Message::user_image_url(url)`                                           | One image from a URL                      |
+| `Message::user_image_bytes(bytes, mime)`                                 | One image from raw bytes (auto base64)    |
+| `Message::new(MessageRole::User, vec![Text, Image, …])`                  | Mixed content / multiple images           |
 | `ContentPart::Image(ImagePart { data, media_type, provider_metadata })`  | Full control + provider-specific hints    |
 
-Each provider sees its own native format:
+Each provider receives whatever native format it wants:
 
 | Provider            | URL                          | Base64 / Bytes                          |
 | ------------------- | ---------------------------- | --------------------------------------- |
@@ -449,9 +528,13 @@ Each provider sees its own native format:
 
 ---
 
-## Cancellation
+## Production
 
-Every request and agent run is cancellable through a `CancellationToken`.
+Code that calls an LLM in production has to deal with three boring-but-essential concerns: stopping work that's no longer wanted, surviving transient failures, and reporting errors usefully.
+
+### Cancellation
+
+Every request and agent run accepts a `CancellationToken`. Cancel the token and the operation stops at the next safe boundary — Aquaregia checks before every HTTP send (via `tokio::select!`, zero overhead on the happy path), after every SSE chunk in streaming responses, and at the top of every agent step.
 
 ```rust
 use aquaregia::{CancellationToken, ErrorCode, GenerateTextRequest};
@@ -471,104 +554,37 @@ let req = GenerateTextRequest::builder("deepseek-v4-pro")
 
 match client.generate(req).await {
     Err(e) if e.code == ErrorCode::Cancelled => println!("cancelled"),
-    other => println!("{other:?}"),
+    other                                    => println!("{other:?}"),
 }
 ```
 
-Agents bind the token at builder time:
+Agents can take the token at builder time so every `agent.run(...)` call uses the same one:
 
 ```rust
 let agent = Agent::builder(client, "deepseek-v4-pro")
     .cancellation_token(token.clone())
     .build()?;
-
-agent.run("hello").await?;
-agent.run_messages(messages).await?;
 ```
 
-Cancellation is checked **before every HTTP send** (via `tokio::select!`, zero overhead on the happy path), **after every SSE chunk** in streaming responses, and **at the top of every agent step** in the tool loop.
+### Retries & timeouts
 
----
-
-## Reliability
-
-### Retries
+Two knobs, set on the client:
 
 ```rust
-let client = LlmClient::openai().api_key(api_key)
-    .max_retries(3)                       // default: 0
+let client = LlmClient::openai()
+    .api_key(api_key)
+    .max_retries(3)                          // default: 0
     .timeout(Duration::from_secs(45))
     .build()?;
 ```
 
-Aquaregia retries automatically on transient classes (`RateLimited`, `ProviderServerError`, `Transport`, `Timeout`) using exponential backoff with jitter. The `Retry-After` header is parsed and honored when present.
+Aquaregia retries on the classes that are actually transient: `RateLimited`, `ProviderServerError`, `Transport`, `Timeout`. Backoff is exponential with jitter. If the provider returns a `Retry-After` header, Aquaregia honours it instead of using its own delay.
 
-Every `Error` carries a `retryable: bool` flag matching the same classification, so you can layer your own retry/circuit-breaker on top if you need finer control.
+Every `Error` also carries `retryable: bool` flagging the same classification, so if you need a custom retry / circuit-breaker layer, you don't have to redo the taxonomy.
 
----
+### Error handling
 
-## Framework integration example (Axum)
-
-Aquaregia intentionally keeps web framework adapters out of the crate. If you're building on Axum, adapt `TextStream` in your application layer:
-
-```rust
-use aquaregia::{BoundClient, GenerateTextRequest, StreamEvent, TextStream};
-use axum::{
-    extract::State,
-    response::{
-        IntoResponse,
-        sse::{Event, Sse},
-    },
-    routing::get,
-    Router,
-};
-use futures_util::StreamExt;
-use std::{convert::Infallible, sync::Arc};
-
-fn to_axum_sse(
-    stream: TextStream,
-) -> impl IntoResponse {
-    Sse::new(stream.map(|item| {
-        let event = match item {
-            Ok(StreamEvent::ReasoningStarted { .. }) => {
-                Event::default().event("reasoning_start").data("{}")
-            }
-            Ok(StreamEvent::ReasoningDelta { text, .. }) => {
-                Event::default().event("reasoning_token").data(text)
-            }
-            Ok(StreamEvent::ReasoningDone { .. }) => {
-                Event::default().event("reasoning_end").data("{}")
-            }
-            Ok(StreamEvent::TextDelta { text }) => Event::default().event("token").data(text),
-            Ok(StreamEvent::ToolCallReady { .. }) => Event::default().event("tool_call").data("{}"),
-            Ok(StreamEvent::Usage { .. }) => Event::default().event("usage").data("{}"),
-            Ok(StreamEvent::Done) => Event::default().event("done").data("{}"),
-            Err(err) => Event::default().event("error").data(err.message),
-        };
-        Ok::<Event, Infallible>(event)
-    }))
-}
-
-async fn chat(State(client): State<Arc<BoundClient>>) -> impl IntoResponse {
-    let stream = client
-        .stream(GenerateTextRequest::from_user_prompt("deepseek-v4-pro", "Hello."))
-        .await
-        .unwrap();
-    to_axum_sse(stream)
-}
-
-let app: Router = Router::new()
-    .route("/chat", get(chat))
-    .with_state(Arc::new(client));
-```
-
-The example keeps non-text payloads minimal; in a real app, serialize tool calls, usage, and reasoning metadata into whatever wire format your frontend expects.
-
-Map the `StreamEvent` variants you care about to named SSE events, websocket messages, or any other transport format your app uses.
-
----
-
-## Error handling
+`Error` is a structured payload, not just a string. Match on `code: ErrorCode` for control flow; read the rest for diagnostics:
 
 ```rust
 use aquaregia::ErrorCode;
@@ -589,13 +605,99 @@ match client.generate(req).await {
 
 Every `Error` carries:
 
-- `code: ErrorCode` — one of 13 normalized variants
-- `provider`, `status`, `request_id`, `raw_body`, `retry_after_secs` — for logging and triage
-- `retryable: bool` — `true` iff Aquaregia's built-in retry will engage
+- `code: ErrorCode` — a normalised variant (the discriminator you actually want to switch on)
+- `provider`, `status`, `request_id`, `raw_body`, `retry_after_secs` — diagnostic fields for logs and support tickets
+- `retryable: bool` — `true` iff Aquaregia's built-in retry would engage
 
 ---
 
-## Examples
+## Integration
+
+Aquaregia keeps web framework adapters out of the crate on purpose — `TextStream` is a `Stream` of `StreamEvent` and adapts cleanly to whatever transport your app already uses.
+
+Here's the Axum SSE pattern. Every `StreamEvent` becomes a named SSE event your frontend can switch on:
+
+```rust
+use aquaregia::{BoundClient, GenerateTextRequest, StreamEvent, TextStream};
+use axum::{
+    extract::State,
+    response::{
+        IntoResponse,
+        sse::{Event, Sse},
+    },
+    routing::get,
+    Router,
+};
+use futures_util::StreamExt;
+use std::{convert::Infallible, sync::Arc};
+
+fn to_axum_sse(stream: TextStream) -> impl IntoResponse {
+    Sse::new(stream.map(|item| {
+        let event = match item {
+            Ok(StreamEvent::ReasoningStarted { .. })       => Event::default().event("reasoning_start").data("{}"),
+            Ok(StreamEvent::ReasoningDelta { text, .. })   => Event::default().event("reasoning_token").data(text),
+            Ok(StreamEvent::ReasoningDone { .. })          => Event::default().event("reasoning_end").data("{}"),
+            Ok(StreamEvent::TextDelta { text })            => Event::default().event("token").data(text),
+            Ok(StreamEvent::ToolCallReady { .. })          => Event::default().event("tool_call").data("{}"),
+            Ok(StreamEvent::Usage { .. })                  => Event::default().event("usage").data("{}"),
+            Ok(StreamEvent::Done)                          => Event::default().event("done").data("{}"),
+            Err(err)                                       => Event::default().event("error").data(err.message),
+        };
+        Ok::<Event, Infallible>(event)
+    }))
+}
+
+async fn chat(State(client): State<Arc<BoundClient>>) -> impl IntoResponse {
+    let stream = client
+        .stream(GenerateTextRequest::from_user_prompt("deepseek-v4-pro", "Hello."))
+        .await
+        .unwrap();
+    to_axum_sse(stream)
+}
+
+let app: Router = Router::new()
+    .route("/chat", get(chat))
+    .with_state(Arc::new(client));
+```
+
+For Actix, Warp, or your own gRPC layer the recipe is identical — map each `StreamEvent` variant to your wire format. The example keeps non-text payloads minimal; in a real app you'd serialise tool calls, usage, and reasoning metadata into whatever shape your frontend already speaks.
+
+---
+
+## Reference
+
+Lookup tables for when you know roughly what you want and need the exact name.
+
+### Capability matrix
+
+| Capability                       | OpenAI | Anthropic | Google | OpenAI-Compatible |
+| -------------------------------- | :----: | :-------: | :----: | :---------------: |
+| Custom `base_url`                |   ✓    |     ✓     |   ✓    |         ✓         |
+| Custom headers / query / path    |        |           |        |         ✓         |
+| `api_version` (header)           |        |     ✓     |        |                   |
+| Structured output                |   ✓    |     ✓     |   ✓    |         ✓         |
+| Tool-call streaming              |   ✓    |     ✓     |   ✓    |         ✓         |
+| Cache-token split in `Usage`     |   ✓    |     ✓     |   ✓    |   if reported     |
+
+### `Usage` fields
+
+```rust
+pub struct Usage {
+    pub input_tokens:             u32, // total
+    pub input_no_cache_tokens:    u32,
+    pub input_cache_read_tokens:  u32,
+    pub input_cache_write_tokens: u32,
+    pub output_tokens:            u32, // total
+    pub output_text_tokens:       u32,
+    pub reasoning_tokens:         u32,
+    pub total_tokens:             u32,
+    pub raw_usage:                Option<serde_json::Value>,
+}
+```
+
+`Usage` implements `Add` and `AddAssign`, so totalling tokens across agent steps is a one-liner. `AgentResponse.usage_total` is already aggregated for you.
+
+### Examples
 
 ```bash
 DEEPSEEK_API_KEY=... cargo run --example basic_generate
@@ -605,6 +707,7 @@ DEEPSEEK_API_KEY=... cargo run --example basic_generate
 | ----------------------------- | ----------------------------------------------------------- |
 | `basic_generate`              | One-shot `generate` + usage reading                         |
 | `basic_stream`                | `stream` + `StreamEvent` handling                           |
+| `structured_streaming`        | `stream_object::<T>()` + progressive `Partial` events       |
 | `agent_minimal`               | `Agent::builder` with one typed tool                        |
 | `tools_max_steps`             | Multi-tool loop with `max_steps` and sampling caps          |
 | `prepare_hooks`               | `prepare_step`, `on_step_finish`                            |
@@ -613,6 +716,10 @@ DEEPSEEK_API_KEY=... cargo run --example basic_generate
 | `multimodal_image`            | `Message::new` with mixed text + image parts + Anthropic vision |
 
 Set `DEEPSEEK_API_KEY` for most examples; `ANTHROPIC_API_KEY` for `multimodal_image`. See [`examples/README.md`](./examples/README.md) for full descriptions.
+
+### API reference
+
+Full type signatures, every public item, every variant — on [docs.rs/aquaregia](https://docs.rs/aquaregia).
 
 ---
 
@@ -637,7 +744,7 @@ This repository also keeps agent-facing guidance principle-based on purpose. Fil
 
 ## Contributing & License
 
-Contributions are welcome. For behavior changes, include integration tests (happy path + error mapping + tool/stream flows where relevant).
+Contributions are welcome. For behaviour changes, include integration tests (happy path + error mapping + tool/stream flows where relevant).
 
 - [Contributing Guide](./CONTRIBUTING.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)

--- a/README_CN.md
+++ b/README_CN.md
@@ -85,7 +85,7 @@ let client = LlmClient::openai().api_key(std::env::var("OPENAI_API_KEY")?)
 
 ### 模型引用
 
-`GenerateTextRequest::from_user_prompt` 和 `.builder()` 接受任何 `impl Into<ModelRef>` —— 最常用的是裸 `&str`：
+`GenerateTextRequest::from_user_prompt` 和 `.builder()` 接受任何 `impl Into<String>` —— 最常用的是裸 `&str`：
 
 ```rust
 let req = GenerateTextRequest::from_user_prompt("gpt-5.5", "Hello!");

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,7 +2,7 @@
 
 # Aquaregia
 
-**Rust 生态的统一 AI 抽象层。**
+**Rust 的通用 AI 层。**
 
 [![Crates.io](https://img.shields.io/crates/v/aquaregia.svg)](https://crates.io/crates/aquaregia)
 [![Docs.rs](https://docs.rs/aquaregia/badge.svg)](https://docs.rs/aquaregia)
@@ -13,117 +13,157 @@
 
 </div>
 
-一个 crate 就能在任一 provider 上构建 LLM 应用与 Agent。
+---
+
+## Introduction
+
+### 为什么是 Aquaregia
+
+你想从 Rust 调用 LLM。半年后你大概率还会想调用_另一家_ LLM——而且不希望为此重写你的 prompt、tool 定义和流式代码。
+
+Aquaregia 是一个 crate，让你用同一套 API 调用 OpenAI、Anthropic、Google 和任意 OpenAI-compatible 端点。换一个构造器，相同的 `generate`、`stream`、`generate_object`、`Agent` 继续工作。流式、结构化输出、推理内容、多模态输入、agent 循环、重试、取消——一切都归一在同一个类型背后。
+
+它不是网关、不是代理、不是微服务。它就是一个 `cargo add` 进来直接调用的 Rust 库。
+
+### 一览
+
+| 能力                              | 你能拿到什么                                                                              |
+| --------------------------------- | ----------------------------------------------------------------------------------------- |
+| **一套 API，四个 provider**       | OpenAI · Anthropic · Google · OpenAI-compatible（DeepSeek、Together、Groq 等）             |
+| **流式与非流式**                  | 同一个 builder 喂给 `generate` 或 `stream`，事件类型统一                                  |
+| **结构化输出**                    | `generate_object::<T>()` 与 `stream_object::<T>()`，schema 由 `schemars` 自动推导          |
+| **推理内容**                      | 一等公民式的 reasoning 提取、流式 reasoning delta、reasoning-token usage                   |
+| **工具型 Agent**                  | 多步循环 + `prepare_step` 钩子 + `max_steps` + `stop_when` + 错误策略                      |
+| **多模态视觉**                    | URL / base64 / 原始字节都支持——一套 `ImagePart` API 通吃所有 provider                       |
+| **取消与重试**                    | `CancellationToken` 全程检查；transient 错误指数退避，遵循 `Retry-After`                   |
+
+### 什么时候不该用
+
+如果你的项目只会接一家 provider，也不在乎可移植性，那家 vendor 的原生 SDK 会给你更地道的接口。Aquaregia 真正发挥价值的场景：**A/B 多个 provider**、**让用户在运行时选模型**、**为未来 LLM 生态变化留余地**。如果上面这些都不沾——你不是目标受众，没关系。
 
 ---
 
 ## 快速上手
+
+### 安装
+
+```bash
+cargo add aquaregia
+```
+
+你的项目还需要一个 Tokio runtime——Aquaregia 全程 async。
+
+### Hello world
+
+调到一个真实模型响应的最短路径：
 
 ```rust
 use aquaregia::{GenerateTextRequest, LlmClient};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = LlmClient::openai_compatible().base_url("https://api.deepseek.com")
+    let client = LlmClient::openai_compatible()
+        .base_url("https://api.deepseek.com")
         .api_key(std::env::var("DEEPSEEK_API_KEY")?)
         .build()?;
 
     let response = client
         .generate(GenerateTextRequest::from_user_prompt(
             "deepseek-v4-pro",
-            "用 3 个要点解释 Rust 所有权。",
+            "Explain Rust ownership in 3 bullet points.",
         ))
         .await?;
 
     println!("{}", response.output_text);
-    println!(
-        "usage: {} → {} tokens",
-        response.usage.input_tokens, response.usage.output_tokens
-    );
     Ok(())
 }
 ```
 
-换一个构造器，同样的调用就能跑在 Anthropic、OpenAI 或 Google 上。
+三个动件：一个 **client**（provider + 认证 + 传输），一个 **request**（model + messages），一次 `.generate()` 调用。本文档剩下的所有内容都是这三件事的细化。
 
----
+### 第一次流式调用
 
-## 安装
+同一个 client，把 `.generate` 换成 `.stream`：
 
-```bash
-cargo add aquaregia
+```rust
+use aquaregia::StreamEvent;
+use futures_util::StreamExt;
+
+let mut stream = client
+    .stream(GenerateTextRequest::from_user_prompt(
+        "deepseek-v4-pro",
+        "Write a haiku about the borrow checker.",
+    ))
+    .await?;
+
+while let Some(event) = stream.next().await {
+    match event? {
+        StreamEvent::TextDelta { text } => print!("{text}"),
+        StreamEvent::Done               => break,
+        _                                => {}
+    }
+}
 ```
 
-项目还需要 Tokio 异步运行时。
+你已经看到了整个 shape——一个 builder、一次调用、要么是返回值要么是事件循环。剩下的章节把每一块拆开。
 
 ---
 
-## Providers
+## 核心
 
-选择一个构造器，获得该 provider 对应的 `BoundClient`。
+### Client
 
-| Provider          | 构造器                                                | 模型参数              |
-| ----------------- | ----------------------------------------------------- | --------------------- |
-| OpenAI            | `LlmClient::openai().api_key(api_key)`                          | `"gpt-5.5"`            |
-| Anthropic         | `LlmClient::anthropic().api_key(api_key)`                       | `"claude-sonnet-4-6"` |
-| Google            | `LlmClient::google().api_key(api_key)`                          | `"gemini-3.5-flash"`  |
-| OpenAI-compatible | `LlmClient::openai_compatible().base_url(base_url).api_key(...)` | `"deepseek-v4-pro"`     |
-
-### 客户端配置
+`LlmClient` 只是构造器的命名空间。每个构造器返回一个用 provider 设置类型参数化的 `ClientBuilder<S>`，最终 `.build()` 出一个可复用的 `BoundClient`。记住这个 shape：**构造器 → builder → bound client**——无论选哪家 provider 都是这个套路。
 
 ```rust
 use std::time::Duration;
 
-let client = LlmClient::openai().api_key(std::env::var("OPENAI_API_KEY")?)
-    .base_url("https://api.openai.com")          // 自定义上游
-    .timeout(Duration::from_secs(60))            // 单次请求超时
-    .max_retries(3)                              // 瞬时失败重试次数
-    .default_max_steps(8)                        // 基于此 client 构造的 Agent 默认 max_steps
+let client = LlmClient::openai()
+    .api_key(std::env::var("OPENAI_API_KEY")?)
+    .base_url("https://api.openai.com")          // 可选：自定义上游
+    .timeout(Duration::from_secs(60))            // 单次请求的 HTTP 超时
+    .max_retries(3)                              // transient 失败重试次数
+    .default_max_steps(8)                        // Agent 默认步数上限
     .user_agent("my-app/1.0")
     .build()?;
 ```
 
-### 模型引用
+切换 provider 只是换个构造器——下面所有方法在任何 `BoundClient` 上的用法都一样。
 
-`GenerateTextRequest::from_user_prompt` 和 `.builder()` 接受任何 `impl Into<String>` —— 最常用的是裸 `&str`：
+| Provider          | 构造器                                                                |
+| ----------------- | -------------------------------------------------------------------- |
+| OpenAI            | `LlmClient::openai().api_key(api_key)`                               |
+| Anthropic         | `LlmClient::anthropic().api_key(api_key).api_version("2023-06-01")`  |
+| Google            | `LlmClient::google().api_key(api_key)`                               |
+| OpenAI-compatible | `LlmClient::openai_compatible().base_url(url).api_key(token)`        |
+
+#### 深一层：OpenAI-compatible 端点
+
+如果你的 provider 说 OpenAI chat-completions 协议但住在另一个 URL——DeepSeek、Together、Groq、你自家网关——`openai_compatible()` 让你叠加自定义 header、query 参数、甚至换 chat path：
 
 ```rust
-let req = GenerateTextRequest::from_user_prompt("gpt-5.5", "Hello!");
-```
-
-### OpenAI-compatible 深度配置
-
-```rust
-let client = LlmClient::openai_compatible().base_url("https://api.deepseek.com")
+let client = LlmClient::openai_compatible()
+    .base_url("https://api.deepseek.com")
     .api_key(std::env::var("DEEPSEEK_API_KEY")?)
     .header("x-trace-source", "aquaregia")
     .query_param("source", "sdk")
-    .chat_completions_path("/v1/chat/completions") // 覆盖默认 endpoint 路径
+    .chat_completions_path("/v1/chat/completions")
     .build()?;
 ```
 
-### Provider 能力差异速查
-
-| 能力                          | OpenAI | Anthropic | Google | OpenAI-Compatible |
-| ----------------------------- | :----: | :-------: | :----: | :---------------: |
-| 自定义 `base_url`             |   ✓    |     ✓     |   ✓    |         ✓         |
-| 自定义 headers / query / path |        |           |        |         ✓         |
-| `api_version`（header）       |        |     ✓     |        |                   |
-| 结构化输出                    |   ✓    |     ✓     |   ✓    |         ✓         |
-| Tool-call 流式输出            |   ✓    |     ✓     |   ✓    |         ✓         |
-| `Usage` 中的缓存 token 拆分   |   ✓    |     ✓     |   ✓    |  provider 上报时  |
+如果端点根本不要 `Authorization` 头，用 `.no_api_key()` 替换 `.api_key(...)`。
 
 ---
 
-## 文本生成
+### 文本生成
 
-### 一次性 `generate`
+`generate` 是主力：一次请求一次响应，所有内容塞在 `output_text` 里。
 
 ```rust
 let response = client
     .generate(GenerateTextRequest::from_user_prompt(
         "deepseek-v4-pro",
-        "用 Go 开发者能听懂的话总结 Rust 借用检查器。",
+        "Summarize Rust's borrow checker for a Go developer.",
     ))
     .await?;
 
@@ -131,7 +171,7 @@ println!("{}", response.output_text);
 println!("finish: {:?}", response.finish_reason);
 ```
 
-需要多条消息、采样参数或工具时使用 builder：
+`from_user_prompt(model, prompt)` 是一行式的。当你需要更多——系统提示词、采样控制、工具——切到 builder：
 
 ```rust
 use aquaregia::{GenerateTextRequest, Message};
@@ -144,13 +184,20 @@ let req = GenerateTextRequest::builder("deepseek-v4-pro")
     .build()?;
 ```
 
-### 流式输出
+model 参数就是一个字符串——Aquaregia 不试图枚举模型 ID，因为每家 provider 几乎每隔几周都会出新型号。直接传你的 provider 文档说当前可用的 ID；如果 provider 拒收，你会拿到一个干净的 `InvalidRequest` 错误。
+
+---
+
+### 流式响应
+
+当消费方是 UI 或终端时，你希望 token 边到边显示，而不是等整段回复落地。把 `generate` 换成 `stream`，然后消费 `StreamEvent`：
 
 ```rust
 use aquaregia::StreamEvent;
 use futures_util::StreamExt;
 
 let mut stream = client.stream(request).await?;
+
 while let Some(event) = stream.next().await {
     match event? {
         StreamEvent::TextDelta { text }          => print!("{text}"),
@@ -166,21 +213,25 @@ while let Some(event) = stream.next().await {
 }
 ```
 
-完整事件：
+事件流是模型能发出的一切事件的全集。你通常只匹配几种，剩下 `_ => {}` 即可。全部菜单如下：
 
-| 事件                 | 字段                                    |
-| -------------------- | --------------------------------------- |
-| `ReasoningStarted`   | `block_id`、`provider_metadata`         |
-| `ReasoningDelta`     | `block_id`、`text`、`provider_metadata` |
-| `ReasoningDone`      | `block_id`、`provider_metadata`         |
-| `TextDelta`          | `text`                                  |
-| `ToolCallReady`      | `call: ToolCall`                        |
-| `Usage`              | `usage: Usage`                          |
-| `Done`               | —                                       |
+| 事件                 | 字段                                    | 何时触发                                       |
+| -------------------- | --------------------------------------- | --------------------------------------------- |
+| `ReasoningStarted`   | `block_id`、`provider_metadata`         | 一个 reasoning 块开始（Anthropic / Google）   |
+| `ReasoningDelta`     | `block_id`、`text`、`provider_metadata` | 每个 thought token                            |
+| `ReasoningDone`      | `block_id`、`provider_metadata`         | 一个 reasoning 块结束                         |
+| `TextDelta`          | `text`                                  | 每个可见回答 token                            |
+| `ToolCallReady`      | `call: ToolCall`                        | 模型完成一次 tool call 的组装                  |
+| `Usage`              | `usage: Usage`                          | provider 回报 token 计数                       |
+| `Done`               | —                                       | 每个 stream 的最后一个事件                     |
+
+`Done` 一旦触发，stream 就结束了——别再 poll。
+
+---
 
 ### Reasoning
 
-reasoning 在同步与流式输出中均可用：
+Reasoning 是模型的"出声思考"——独立于可见回答，被 Anthropic Extended Thinking、Google `thoughts`、OpenAI 的 reasoning-token 账目作为单独内容块暴露。Aquaregia 用统一形式呈现：
 
 ```rust
 let out = client.generate(req).await?;
@@ -191,39 +242,26 @@ println!("rsn-tokens: {}", out.usage.reasoning_tokens);
 
 for part in &out.reasoning_parts {
     println!("[block] {}", part.text);
-    // part.provider_metadata 承载 Anthropic 的 signature、Google 的 thoughtSignature 等元数据
+    // part.provider_metadata 载入 signature 块（Anthropic）、
+    // thought signature（Google）以及其他 provider 私有附加。
 }
 ```
 
-| Provider                   | Usage 映射                                                                                  |
+在 streaming 中，可见文本前会先看到每个 reasoning 块的 `ReasoningStarted` → `ReasoningDelta`(s) → `ReasoningDone`。token usage 的拆分来自各 provider 填写的字段：
+
+| Provider                   | Reasoning-token 字段映射                                                                    |
 | -------------------------- | ------------------------------------------------------------------------------------------- |
-| OpenAI / OpenAI-compatible | 解析 `prompt_tokens_details.cached_tokens` + `completion_tokens_details.reasoning_tokens`   |
-| Anthropic                  | 解析 `cache_read_input_tokens` / `cache_creation_input_tokens`；reasoning token 细分暂不可用 |
-| Google                     | 解析 `cachedContentTokenCount` + `thoughtsTokenCount`                                       |
+| OpenAI / OpenAI-compatible | `prompt_tokens_details.cached_tokens` + `completion_tokens_details.reasoning_tokens`        |
+| Anthropic                  | `cache_read_input_tokens` / `cache_creation_input_tokens`；reasoning-token 拆分不可用        |
+| Google                     | `cachedContentTokenCount` + `thoughtsTokenCount`                                            |
 
-### `Usage` 与聚合
-
-```rust
-pub struct Usage {
-    pub input_tokens:             u32, // 总输入
-    pub input_no_cache_tokens:    u32,
-    pub input_cache_read_tokens:  u32,
-    pub input_cache_write_tokens: u32,
-    pub output_tokens:            u32, // 总输出
-    pub output_text_tokens:       u32,
-    pub reasoning_tokens:         u32,
-    pub total_tokens:             u32,
-    pub raw_usage:                Option<serde_json::Value>,
-}
-```
-
-`Usage` 实现了 `Add` 与 `AddAssign`，跨 Agent 步骤累加是一行的事。`AgentResponse.usage_total` 已经为你聚合好了。
+如果 provider 没报某个数，对应字段保持 `0`——Aquaregia 从不编造数据。
 
 ---
 
-## 结构化输出
+### 结构化输出
 
-调用 `generate_object::<T>()` 即可直接拿到 Rust 类型——无需手动解析 JSON。JSON Schema 由 `schemars` 从你的类型自动推导。
+当你想拿回一个类型化的 Rust 值而不是一段文本，给类型 derive `JsonSchema`，然后调 `generate_object::<T>()`。schema 自动生成并传给 provider；返回的 JSON 直接反序列化进 `T`。
 
 ```rust
 use aquaregia::{GenerateTextRequest, LlmClient, Message};
@@ -236,34 +274,57 @@ struct WeatherResult {
     temp_c: f64,
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = LlmClient::openai().api_key(std::env::var("OPENAI_API_KEY")?).build()?;
+let req = GenerateTextRequest::builder("gpt-5.5")
+    .message(Message::user_text("What is the weather in Tokyo?"))
+    .temperature(0.2)
+    .build()?;
 
-    let req = GenerateTextRequest::builder("gpt-5.5")
-        .message(Message::user_text("东京天气怎么样？"))
-        .temperature(0.2)
-        .build()?;
+let result = client.generate_object::<WeatherResult>(req).await?;
 
-    let result = client.generate_object::<WeatherResult>(req).await?;
+println!("{} → {}°C", result.object.city, result.object.temp_c);
+```
 
-    println!("城市: {}，温度: {}°C", result.object.city, result.object.temp_c);
-    println!("tokens: {} in / {} out", result.usage.input_tokens, result.usage.output_tokens);
-    Ok(())
+不支持原生结构化输出的 provider（Anthropic、Google）会透明地降级到强制 tool call。从调用方视角看完全一样——你拿到的都是一个 `T`。
+
+#### 流式 partial 对象
+
+当 UI 需要字段一到位就渲染时，`stream_object::<T>()` 会持续输出渐进填充的对象。每个 chunk 都会被修复后重新反序列化成 partial `T`。尚未到达的字段保持 `Default`，所以请给类型 derive `Default` 并加 `#[serde(default)]`：
+
+```rust
+use aquaregia::{GenerateTextRequest, LlmClient, Message, StreamObjectEvent};
+use futures_util::StreamExt;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(default)]
+struct WeatherResult {
+    city:   String,
+    temp_c: f64,
+}
+
+let mut stream = client.stream_object::<WeatherResult>(req).await?;
+while let Some(event) = stream.next().await {
+    match event? {
+        StreamObjectEvent::Partial { partial } => {
+            println!("partial: {} ({}°C)", partial.city, partial.temp_c);
+        }
+        StreamObjectEvent::Object { object } => {
+            println!("final:   {:?}", object);
+        }
+    }
 }
 ```
 
-所有 provider 产出相同的类型化输出——提取策略对调用方完全透明。
+底层是一个基于栈的 JSON 修复器，处理截断字符串、未闭合的数组/对象、token 中间的转义序列。即使 chunk 把字段名或值切成两半也能拼出合法 partial——你在自己代码里永远不用处理非法 JSON。完整可运行示例见 `examples/structured_streaming.rs`。
 
 ---
 
-## Tools 与 Agents
+### 工具
 
-### 定义工具
+Tool 让模型在对话中段调用你的 Rust 代码。把一个 tool 想成**一个带 schema 的 `async fn`，LLM 按名字调用它**——Aquaregia 从你的参数类型推导 JSON Schema，把调用参数 marshal 回 Rust，再运行你的函数。
 
-工具通过 `tool(name)` 函数构造。支持两种执行模式。
-
-**类型化参数** —— `schemars` 自动从 struct 推导 JSON Schema：
+类型化风格是最常用的：
 
 ```rust
 use aquaregia::{Tool, tool};
@@ -283,7 +344,9 @@ fn get_weather() -> Tool {
 }
 ```
 
-**原始 schema** —— 手写 JSON Schema，回调收到 `serde_json::Value`：
+`tool(name)` 启动一个 builder；`.execute(closure)` 接收一个 `JsonSchema`-derived 的参数类型并完成构建。closure 返回 `Result<serde_json::Value, ToolExecError>`——模型拿到的是你产出的任何 JSON。
+
+如果你想手写 schema（约束特殊、不方便用 derive），改用 `.raw_schema(...)` + `.execute_raw(...)`：
 
 ```rust
 let fx_tool = tool("get_fx_rate")
@@ -299,31 +362,40 @@ let fx_tool = tool("get_fx_rate")
     });
 ```
 
-工具名必须匹配 `^[a-zA-Z0-9_-]{1,64}$`，且在同一个 Agent 内唯一。
+Tool 名必须匹配 `^[a-zA-Z0-9_-]{1,64}$` 且在一个 agent 内唯一。这条规则在 agent 构建时就校验——非法的工具表永远到不了模型那边。
 
-### 最小 Agent
+---
+
+### Agent
+
+`Agent` 是一个 `generate` 加工具的 `while` 循环外加钩子：模型思考 → 也许调工具 → 你跑工具 → 结果回到模型 → 重复，直到模型不再调工具（或你设了上限）。你不写这个循环，你只描述它的输入与输出。
+
+最小 agent 是一个工具加一个步数上限：
 
 ```rust
 use aquaregia::{Agent, LlmClient};
 
-let client = LlmClient::openai_compatible().base_url("https://api.deepseek.com")
+let client = LlmClient::openai_compatible()
+    .base_url("https://api.deepseek.com")
     .api_key(std::env::var("DEEPSEEK_API_KEY")?)
     .build()?;
 
 let agent = Agent::builder(client, "deepseek-v4-pro")
-    .instructions("回答前可以先调用工具。")
+    .instructions("You can call tools before answering.")
     .tools([get_weather])
     .max_steps(4)
     .build()?;
 
-let response = agent.run("上海天气怎么样？").await?;
+let response = agent.run("Weather in Shanghai?").await?;
 println!("{}", response.output_text);
 println!("steps={} total={}", response.steps, response.usage_total.total_tokens);
 ```
 
-### 事件钩子
+`response.output_text` 是最终给用户看的回答。`response.steps` 告诉你跑了几个 round-trip；`response.usage_total` 跨所有调用聚合 token 数。
 
-Agent 循环在每个关键边界都会触发事件。所有钩子都是 `Fn + Send + Sync`，可以直接传闭包。
+#### 事件钩子
+
+循环里每个有意思的边界都会发事件。所有钩子都是 `Fn + Send + Sync`，可以直接挂闭包——做日志、metrics、debug UI 都好使：
 
 ```rust
 let agent = Agent::builder(client, "deepseek-v4-pro")
@@ -337,9 +409,9 @@ let agent = Agent::builder(client, "deepseek-v4-pro")
     .build()?;
 ```
 
-### 动态规划 —— `prepare_step`
+#### 动态规划 —— `prepare_step`
 
-`prepare_step` 在每一步前运行，返回一份新的 prepared plan —— 适合裁剪工具集、切换模型、注入分步指令：
+当你需要在下一步开跑前改它——收窄工具集、换模型、临时塞个系统提示——给 agent 一个 `prepare_step` 闭包：
 
 ```rust
 use aquaregia::Message;
@@ -349,40 +421,44 @@ let agent = Agent::builder(client, "deepseek-v4-pro")
     .prepare_step(|event| {
         let mut next = event.to_prepared();
         next.messages.push(Message::system_text(format!(
-            "Step {}: 简洁回复。", event.step,
+            "Step {}: be concise.", event.step,
         )));
         if event.step >= 2 {
-            next.tools.clear(); // 第 2 步起禁用工具
+            next.tools.clear(); // 第 2 步后禁用工具
         }
         next
     })
     .build()?;
 ```
 
-### 停止策略
+返回的 `AgentPreparedStep` 就是 agent 实际发给模型的这一步内容。你没改的部分会从上一步状态继承下来。
+
+#### 停止策略
+
+控制循环何时结束的三个旋钮：
 
 ```rust
 use aquaregia::ToolErrorPolicy;
 
 let agent = Agent::builder(client, "deepseek-v4-pro")
-    .max_steps(8)                                                                 // 硬上限
-    .stop_when(|step| step.tool_calls.is_empty() && !step.output_text.is_empty()) // 提前停止谓词
-    .tool_error_policy(ToolErrorPolicy::ContinueAsToolResult)                     // 默认
+    .max_steps(8)
+    .stop_when(|step| step.tool_calls.is_empty() && !step.output_text.is_empty())
+    .tool_error_policy(ToolErrorPolicy::ContinueAsToolResult)
     .build()?;
 ```
 
-- `max_steps` —— 超出返回 `ErrorCode::MaxStepsExceeded`。
-- `stop_when` —— 每步结束后评估的谓词，为真则提前停止。
-- `tool_error_policy` ——
-  - `ContinueAsToolResult`（默认）—— schema 校验失败、超时、panic 都会变成 `{ "error": "..." }` 的 tool result，让模型自行恢复。
+- **`max_steps`** —— 硬上限。超出返回 `ErrorCode::MaxStepsExceeded`，不会静默截断。
+- **`stop_when`** —— 每步结束后判断的谓词。当你对"完成"有更精细的定义（而不仅仅是"没有 tool call"）时用它。
+- **`tool_error_policy`** —— 工具 throw 时怎么办。
+  - `ContinueAsToolResult`（默认） —— schema 校验失败、超时、panic 都会被包成 `{ "error": "..." }` 结果，让模型下一步自行恢复。
   - `FailFast` —— 直接抛出 `ErrorCode::ToolExecutionFailed` / `InvalidToolArgs`。
 
-### 多轮对话
+#### 多轮对话
 
-`AgentResponse.transcript` 是一份完整的 `Vec<Message>`（system + user + assistant + tool 结果），可以直接喂回下一轮：
+`AgentResponse.transcript` 是一个完整的 `Vec<Message>`（system + user + assistant + tool results），可以直接喂给下一轮——不用手动拼装：
 
 ```rust
-let mut history = vec![Message::system_text("你是一名严谨的助手。")];
+let mut history = vec![Message::system_text("You are a careful assistant.")];
 
 loop {
     let user_input = read_line()?;
@@ -391,15 +467,19 @@ loop {
     let result = agent.run_messages(history.clone()).await?;
     println!("{}", result.output_text);
 
-    history = result.transcript; // 把完整对话回滚到下一轮
+    history = result.transcript; // 整段对话原地回流
 }
 ```
 
-`examples/mini_claude_code.rs` 给出了一个使用此模式 + `bash` / `read` / `write` / `edit` 工具的终端 Agent 示例。
+`examples/mini_claude_code.rs` 用这个模式 + `bash` / `read` / `write` / `edit` 工具组合给出了一个可跑的终端 agent。
 
 ---
 
-## 多模态视觉
+### 多模态
+
+视觉模型既吃文本也吃图像。Aquaregia 用一个 `ImagePart` 把各 provider 之间的差异屏蔽掉——你说一次"URL"或"bytes"，正确的事情就发生在线路上。
+
+最短路径是 `Message::user_image_url` 或 `Message::user_image_bytes`。当一条消息要混合内容或多张图，用 explicit content parts 构造 `Message`：
 
 ```rust
 use aquaregia::{
@@ -414,7 +494,7 @@ let out = client
             .message(Message::new(
                 MessageRole::User,
                 vec![
-                    ContentPart::Text("这张图里有什么？".into()),
+                    ContentPart::Text("What's in this image?".into()),
                     ContentPart::Image(ImagePart {
                         data: MediaData::Url(
                             "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg".into(),
@@ -429,28 +509,32 @@ let out = client
     .await?;
 ```
 
-两个便捷构造器 + 一个完全自定义形式：
+便捷构造器：
 
-| 构造器                                                                  | 场景                                  |
-| ----------------------------------------------------------------------- | ------------------------------------- |
-| `Message::user_image_url(url)`                                          | 单张图像，来自 URL                    |
-| `Message::user_image_bytes(bytes, mime)`                                | 单张图像，来自原始字节（自动 base64） |
-| `Message::new(MessageRole::User, vec![Text, Image, …])`                 | 混合内容（文字 + 图像、多图）          |
-| `ContentPart::Image(ImagePart { data, media_type, provider_metadata })` | 完全自定义，可附带 provider 专用提示  |
+| 构造器                                                                   | 用途                                       |
+| ------------------------------------------------------------------------ | ------------------------------------------ |
+| `Message::user_image_url(url)`                                           | 单张图像，来自 URL                          |
+| `Message::user_image_bytes(bytes, mime)`                                 | 单张图像，来自原始字节（自动 base64）       |
+| `Message::new(MessageRole::User, vec![Text, Image, …])`                  | 混合内容 / 多图                             |
+| `ContentPart::Image(ImagePart { data, media_type, provider_metadata })`  | 完整控制 + provider 私有附加                |
 
-各 provider 接收各自的原生格式：
+每个 provider 拿到的都是自己的原生格式：
 
-| Provider            | URL                          | Base64 / 字节                           |
+| Provider            | URL                          | Base64 / Bytes                          |
 | ------------------- | ---------------------------- | --------------------------------------- |
 | Anthropic           | `source.type: url`           | `source.type: base64`                   |
-| OpenAI / Compatible | `image_url`（远程 URL）      | `image_url`（`data:<mime>;base64,…`）   |
+| OpenAI / Compatible | `image_url` with remote URL  | `image_url` with `data:<mime>;base64,…` |
 | Google              | `fileData.fileUri`           | `inlineData.data`                       |
 
 ---
 
-## 取消
+## 生产化
 
-每次请求与 Agent 运行都可以通过 `CancellationToken` 取消。
+生产环境调 LLM 要面对三个枯燥但绕不开的事：停止不再需要的工作、扛住瞬时失败、把错误报得有用。
+
+### 取消
+
+每个请求和 agent run 都接受一个 `CancellationToken`。取消 token，下一个安全 checkpoint 就停——Aquaregia 在每次 HTTP 发送前（通过 `tokio::select!`，happy path 零开销）、每个流式 SSE chunk 之后、每个 agent step 顶部都会检查。
 
 ```rust
 use aquaregia::{CancellationToken, ErrorCode, GenerateTextRequest};
@@ -464,51 +548,74 @@ tokio::spawn(async move {
 });
 
 let req = GenerateTextRequest::builder("deepseek-v4-pro")
-    .user_prompt("写一篇一万字的文章。")
+    .user_prompt("Write a 10,000-word essay.")
     .cancellation_token(token)
     .build()?;
 
 match client.generate(req).await {
-    Err(e) if e.code == ErrorCode::Cancelled => println!("已取消"),
-    other => println!("{other:?}"),
+    Err(e) if e.code == ErrorCode::Cancelled => println!("cancelled"),
+    other                                    => println!("{other:?}"),
 }
 ```
 
-Agent 在 builder 上绑定取消令牌：
+Agent 可以在 builder 阶段就绑 token，这样每次 `agent.run(...)` 都用同一个：
 
 ```rust
 let agent = Agent::builder(client, "deepseek-v4-pro")
     .cancellation_token(token.clone())
     .build()?;
-
-agent.run("你好").await?;
-agent.run_messages(messages).await?;
 ```
 
-取消检查点：**每次 HTTP 发送前**（通过 `tokio::select!`，未取消时零开销）、**每个 SSE chunk 之后**、**工具循环中每个 Agent 步骤开始时**。
+### 重试与超时
 
----
-
-## 可靠性
-
-### 重试
+两个旋钮，挂在 client 上：
 
 ```rust
-let client = LlmClient::openai().api_key(api_key)
-    .max_retries(3)                       // 默认 0
+let client = LlmClient::openai()
+    .api_key(api_key)
+    .max_retries(3)                          // 默认：0
     .timeout(Duration::from_secs(45))
     .build()?;
 ```
 
-Aquaregia 会在瞬时错误（`RateLimited`、`ProviderServerError`、`Transport`、`Timeout`）上自动重试，采用带 jitter 的指数退避。响应中如带 `Retry-After`，会解析并遵守。
+Aquaregia 只在确实是瞬时的类目上重试：`RateLimited`、`ProviderServerError`、`Transport`、`Timeout`。退避策略是指数加 jitter。若 provider 返回 `Retry-After` 头，Aquaregia 会遵守它而不是用自己的延时。
 
-每个 `Error` 都带 `retryable: bool` 字段，标识与内置重试相同的判定，你可以在外层自行叠加自己的重试 / 熔断策略。
+每个 `Error` 还带 `retryable: bool`，分类口径相同——如果你想加自己的重试 / 断路器，不必重做一遍分类法。
+
+### 错误处理
+
+`Error` 是结构化 payload 而不是一串字符串。`code: ErrorCode` 用来做控制流分支，其余字段用来诊断：
+
+```rust
+use aquaregia::ErrorCode;
+
+match client.generate(req).await {
+    Ok(out) => println!("{}", out.output_text),
+    Err(e) => match e.code {
+        ErrorCode::RateLimited        => eprintln!("retry after {:?}s", e.retry_after_secs),
+        ErrorCode::AuthFailed         => eprintln!("bad API key"),
+        ErrorCode::Cancelled          => eprintln!("cancelled"),
+        ErrorCode::MaxStepsExceeded   => eprintln!("agent loop too long"),
+        ErrorCode::InvalidToolArgs    => eprintln!("schema mismatch: {}", e.message),
+        ErrorCode::Timeout            => eprintln!("upstream timed out"),
+        _                              => eprintln!("error: {e}"),
+    },
+}
+```
+
+每个 `Error` 都带：
+
+- `code: ErrorCode` —— 归一化变体（这才是你真正想 `match` 的分支器）
+- `provider`、`status`、`request_id`、`raw_body`、`retry_after_secs` —— 日志和工单用的诊断字段
+- `retryable: bool` —— `true` 当且仅当 Aquaregia 内置重试会处理
 
 ---
 
-## 框架集成示例（Axum）
+## 集成
 
-Aquaregia 有意不在主 crate 中内置 Web 框架适配层。如果你在用 Axum，可以在应用代码里自行把 `TextStream` 转成 SSE：
+Aquaregia 故意把 Web 框架适配器留在 crate 之外——`TextStream` 是一个 `StreamEvent` 的 `Stream`，干净地接到你 app 已经在用的任意传输层。
+
+下面是 Axum SSE 的形态。每个 `StreamEvent` 变成一个命名 SSE 事件，前端可以 switch：
 
 ```rust
 use aquaregia::{BoundClient, GenerateTextRequest, StreamEvent, TextStream};
@@ -524,25 +631,17 @@ use axum::{
 use futures_util::StreamExt;
 use std::{convert::Infallible, sync::Arc};
 
-fn to_axum_sse(
-    stream: TextStream,
-) -> impl IntoResponse {
+fn to_axum_sse(stream: TextStream) -> impl IntoResponse {
     Sse::new(stream.map(|item| {
         let event = match item {
-            Ok(StreamEvent::ReasoningStarted { .. }) => {
-                Event::default().event("reasoning_start").data("{}")
-            }
-            Ok(StreamEvent::ReasoningDelta { text, .. }) => {
-                Event::default().event("reasoning_token").data(text)
-            }
-            Ok(StreamEvent::ReasoningDone { .. }) => {
-                Event::default().event("reasoning_end").data("{}")
-            }
-            Ok(StreamEvent::TextDelta { text }) => Event::default().event("token").data(text),
-            Ok(StreamEvent::ToolCallReady { .. }) => Event::default().event("tool_call").data("{}"),
-            Ok(StreamEvent::Usage { .. }) => Event::default().event("usage").data("{}"),
-            Ok(StreamEvent::Done) => Event::default().event("done").data("{}"),
-            Err(err) => Event::default().event("error").data(err.message),
+            Ok(StreamEvent::ReasoningStarted { .. })       => Event::default().event("reasoning_start").data("{}"),
+            Ok(StreamEvent::ReasoningDelta { text, .. })   => Event::default().event("reasoning_token").data(text),
+            Ok(StreamEvent::ReasoningDone { .. })          => Event::default().event("reasoning_end").data("{}"),
+            Ok(StreamEvent::TextDelta { text })            => Event::default().event("token").data(text),
+            Ok(StreamEvent::ToolCallReady { .. })          => Event::default().event("tool_call").data("{}"),
+            Ok(StreamEvent::Usage { .. })                  => Event::default().event("usage").data("{}"),
+            Ok(StreamEvent::Done)                          => Event::default().event("done").data("{}"),
+            Err(err)                                       => Event::default().event("error").data(err.message),
         };
         Ok::<Event, Infallible>(event)
     }))
@@ -550,7 +649,7 @@ fn to_axum_sse(
 
 async fn chat(State(client): State<Arc<BoundClient>>) -> impl IntoResponse {
     let stream = client
-        .stream(GenerateTextRequest::from_user_prompt("deepseek-v4-pro", "你好。"))
+        .stream(GenerateTextRequest::from_user_prompt("deepseek-v4-pro", "Hello."))
         .await
         .unwrap();
     to_axum_sse(stream)
@@ -561,40 +660,44 @@ let app: Router = Router::new()
     .with_state(Arc::new(client));
 ```
 
-示例里把非文本事件的 payload 简化了；实际项目中，你通常会把 tool call、usage、reasoning metadata 序列化成前端约定的格式。
-
-你可以按需把 `StreamEvent` 映射成命名 SSE 事件、WebSocket 消息，或任何适合你应用的传输格式。
+Actix、Warp、或你自家的 gRPC 层用同样的食谱——把每个 `StreamEvent` 变体映射到你自己的线协议。这里的示例为了简洁把非文本载荷都最小化了；实际项目你通常要把 tool call、usage、reasoning metadata 序列化成前端约定的 shape。
 
 ---
 
-## 错误处理
+## 参考
+
+当你知道想要什么、只差一个准确名字时查这里。
+
+### Provider 能力矩阵
+
+| 能力                              | OpenAI | Anthropic | Google | OpenAI-Compatible |
+| --------------------------------- | :----: | :-------: | :----: | :---------------: |
+| 自定义 `base_url`                 |   ✓    |     ✓     |   ✓    |         ✓         |
+| 自定义 headers / query / path     |        |           |        |         ✓         |
+| `api_version`（header）           |        |     ✓     |        |                   |
+| Structured output                 |   ✓    |     ✓     |   ✓    |         ✓         |
+| Tool-call streaming               |   ✓    |     ✓     |   ✓    |         ✓         |
+| `Usage` 中 cache-token 拆分       |   ✓    |     ✓     |   ✓    |   有就报          |
+
+### `Usage` 字段
 
 ```rust
-use aquaregia::ErrorCode;
-
-match client.generate(req).await {
-    Ok(out) => println!("{}", out.output_text),
-    Err(e) => match e.code {
-        ErrorCode::RateLimited        => eprintln!("retry after {:?}s", e.retry_after_secs),
-        ErrorCode::AuthFailed         => eprintln!("API key 无效"),
-        ErrorCode::Cancelled          => eprintln!("已取消"),
-        ErrorCode::MaxStepsExceeded   => eprintln!("Agent 循环超出步数上限"),
-        ErrorCode::InvalidToolArgs    => eprintln!("schema 校验失败: {}", e.message),
-        ErrorCode::Timeout            => eprintln!("上游超时"),
-        _                              => eprintln!("error: {e}"),
-    },
+pub struct Usage {
+    pub input_tokens:             u32, // 总和
+    pub input_no_cache_tokens:    u32,
+    pub input_cache_read_tokens:  u32,
+    pub input_cache_write_tokens: u32,
+    pub output_tokens:            u32, // 总和
+    pub output_text_tokens:       u32,
+    pub reasoning_tokens:         u32,
+    pub total_tokens:             u32,
+    pub raw_usage:                Option<serde_json::Value>,
 }
 ```
 
-每个 `Error` 都包含：
+`Usage` 实现了 `Add` 和 `AddAssign`，跨 agent 步骤累加是一行的事。`AgentResponse.usage_total` 已经为你聚合好。
 
-- `code: ErrorCode` —— 13 种归一化错误码之一
-- `provider`、`status`、`request_id`、`raw_body`、`retry_after_secs` —— 用于日志和定位
-- `retryable: bool` —— 为 `true` 当且仅当 Aquaregia 内置重试会处理它
-
----
-
-## 示例
+### 示例
 
 ```bash
 DEEPSEEK_API_KEY=... cargo run --example basic_generate
@@ -604,14 +707,19 @@ DEEPSEEK_API_KEY=... cargo run --example basic_generate
 | ----------------------------- | ------------------------------------------------------------- |
 | `basic_generate`              | 一次性 `generate` + 读取 usage                                |
 | `basic_stream`                | `stream` + `StreamEvent` 处理                                 |
+| `structured_streaming`        | `stream_object::<T>()` + 渐进式 `Partial` 事件                |
 | `agent_minimal`               | `Agent::builder` + 单个类型化工具                             |
 | `tools_max_steps`             | 多工具循环 + `max_steps` + 采样参数                           |
-| `prepare_hooks`               | `prepare_step`、`on_step_finish`                             |
+| `prepare_hooks`               | `prepare_step`、`on_step_finish`                              |
 | `openai_compatible_custom`    | 自定义 headers / query params / chat path                     |
 | `mini_claude_code`            | TUI Code Agent —— `bash` / `read` / `write` / `edit` 工具     |
 | `multimodal_image`            | `Message::new` 组合文字 + 图像 part + Anthropic 视觉           |
 
 大多数示例需要 `DEEPSEEK_API_KEY`；`multimodal_image` 需要 `ANTHROPIC_API_KEY`。完整说明见 [`examples/README.md`](./examples/README.md)。
+
+### API 参考
+
+完整类型签名、所有公开项、所有变体——见 [docs.rs/aquaregia](https://docs.rs/aquaregia)。
 
 ---
 
@@ -628,17 +736,17 @@ cargo clippy -- -D warnings
 
 ## AI 辅助开发
 
-本项目允许并鼓励使用 AI 辅助开发，但提交者仍然对最终结果负责。无论代码、测试、文档还是 API 变更是否借助 AI 生成，提交它的人都应当真正理解、认真审查并完成必要验证。
+本项目欢迎 AI 辅助开发，但提交人对最终结果负责。如果代码、测试、文档或 API 变更是借助 AI 提出的，提交者依然要能理解、审查、并验证它们。
 
-本仓库也刻意让 agent-facing 文档保持“原则导向”。像 `AGENTS.md`、`CLAUDE.md` 这类文件，应该描述长期稳定的约束、判断规则与协作方式，而不是罗列大量会快速漂移的内部 API 清单。
+仓库里也刻意让 agent 面向的文档保持原则导向。`AGENTS.md`、`CLAUDE.md` 这类文件应该描述长期生效的约束和判断规则，而不是一堆很快就会与代码漂移开的内部 API checklist。
 
 ---
 
 ## 贡献与许可
 
-欢迎贡献。涉及行为变更时，请补充集成测试（happy path + 错误映射 + tool/stream 流程）。
+欢迎贡献。涉及行为变化时，请附上集成测试（happy path + 错误映射 + tool/stream 流程，按相关性选择）。
 
 - [贡献指南](./CONTRIBUTING.md)
 - [行为准则](./CODE_OF_CONDUCT.md)
 - [安全策略](./SECURITY.md)
-- [MIT 许可证](./LICENSE)
+- 基于 [MIT License](./LICENSE) 发布

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,20 +23,20 @@
 - 场景：流式输出到 CLI/UI。
 - 重点：`stream` 消费 `StreamEvent`；可同时处理 `ReasoningStarted/ReasoningDelta/ReasoningDone`、`TextDelta`、`Usage`、`Done`。
 
-3. `agent_minimal.rs`
+3. `structured_streaming.rs`
+
+- 场景：流式拿结构化输出，字段逐个到达即可消费。
+- 重点：`stream_object::<T>()`、`StreamObjectEvent::Partial`/`Object`、`#[serde(default)]` 默认值约定、内置 partial JSON 修复。
+
+4. `agent_minimal.rs`
 
 - 场景：最小 Agent + 单工具。
 - 重点：`Agent::builder(client, model)`、`tool()` builder、`tools([...])` 批量注册、`max_steps(...)`。
 
-4. `tools_max_steps.rs`
+5. `tools_max_steps.rs`
 
 - 场景：循环 + 多工具 + 步数保护。
 - 重点：多个 tool 定义、`max_steps`、多步推理收敛。
-
-5. `google_generate.rs`
-
-- 场景：一次性调用（OpenAI-compatible 接口）。
-- 重点：`generate` 的最小调用路径。
 
 6. `openai_compatible_custom.rs`
 
@@ -63,12 +63,13 @@
 
 1. `basic_generate.rs`
 2. `basic_stream.rs`
-3. `agent_minimal.rs`
-4. `tools_max_steps.rs`
-5. `openai_compatible_custom.rs`
-6. `mini_claude_code.rs`
-7. `prepare_hooks.rs`
-8. `multimodal_image.rs`
+3. `structured_streaming.rs`
+4. `agent_minimal.rs`
+5. `tools_max_steps.rs`
+6. `openai_compatible_custom.rs`
+7. `mini_claude_code.rs`
+8. `prepare_hooks.rs`
+9. `multimodal_image.rs`
 
 ## Web 框架集成说明
 

--- a/examples/structured_streaming.rs
+++ b/examples/structured_streaming.rs
@@ -1,0 +1,77 @@
+use aquaregia::{GenerateTextRequest, LlmClient, Message, StreamObjectEvent};
+use futures_util::StreamExt;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+const DEFAULT_DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com";
+const DEFAULT_DEEPSEEK_MODEL: &str = "deepseek-v4-pro";
+
+/// 场景：流式获取结构化输出，每个字段到位即可读，无需等整段 JSON 拼完。
+///
+/// `stream_object` 内部带 partial JSON 修复：截断的字符串/数组/嵌套对象
+/// 会被补齐成合法 JSON，再尝试反序列化为 `T`。未到达的字段保持 `Default`，
+/// 所以 `T` 推荐整体加 `#[serde(default)]`。
+///
+/// 运行：
+/// DEEPSEEK_API_KEY=... cargo run --example structured_streaming
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(default)]
+struct ProductBrief {
+    name: String,
+    tagline: String,
+    key_features: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("DEEPSEEK_API_KEY")?;
+    let base_url = std::env::var("DEEPSEEK_BASE_URL")
+        .unwrap_or_else(|_| DEFAULT_DEEPSEEK_BASE_URL.to_string());
+    let model =
+        std::env::var("DEEPSEEK_MODEL").unwrap_or_else(|_| DEFAULT_DEEPSEEK_MODEL.to_string());
+
+    let client = LlmClient::openai_compatible()
+        .base_url(base_url)
+        .api_key(api_key)
+        .build()?;
+
+    let req = GenerateTextRequest::builder(model)
+        .message(Message::user_text(
+            "Generate a short product brief for a Rust LLM SDK. \
+             Include a punchy tagline and 4 key features.",
+        ))
+        .temperature(0.3)
+        .build()?;
+
+    let mut stream = client.stream_object::<ProductBrief>(req).await?;
+
+    let mut partial_count = 0u32;
+    println!("=== progressive partials ===");
+    while let Some(event) = stream.next().await {
+        match event? {
+            StreamObjectEvent::Partial { partial } => {
+                partial_count += 1;
+                println!(
+                    "[partial #{}] name={:?} features={}",
+                    partial_count,
+                    partial.name,
+                    partial.key_features.len()
+                );
+            }
+            StreamObjectEvent::Object { object } => {
+                println!("\n=== final object ===");
+                println!("name:     {}", object.name);
+                println!("tagline:  {}", object.tagline);
+                println!("features: {}", object.key_features.len());
+                for (i, f) in object.key_features.iter().enumerate() {
+                    println!("  {}. {}", i + 1, f);
+                }
+            }
+        }
+    }
+    println!(
+        "\n--- emitted {} partial(s) before final ---",
+        partial_count
+    );
+    Ok(())
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -75,9 +75,7 @@ mod sealed {
 /// providers should add an adapter to the `model_adapters` module rather
 /// than implementing this trait.
 pub trait BuildProvider: sealed::Sealed {
-    #[doc(hidden)]
     fn validate(&self) -> Result<(), Error>;
-    #[doc(hidden)]
     fn into_adapter(self, http: Arc<reqwest::Client>) -> Arc<dyn ModelAdapter>;
 }
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,11 +1,10 @@
-//! Tool definition, execution, and registry types for Aquaregia agents.
+//! Tool definition and execution types for Aquaregia agents.
 //!
 //! This module provides the tool abstraction for LLM function calling:
 //!
 //! - [`Tool`]: Runtime tool value with descriptor and executor
 //! - [`ToolDescriptor`]: Serializable tool metadata sent to providers
 //! - [`ToolExecutor`]: Async trait for tool execution
-//! - [`ToolRegistry`]: Validated registry of tools keyed by name
 //! - [`tool()`]: Builder for creating tools with typed arguments
 //! ## Defining Tools
 //!
@@ -49,7 +48,7 @@ use crate::error::{Error, ErrorCode};
 /// Serializable description of a callable tool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolDescriptor {
-    /// Unique tool name (validated by [`ToolRegistry`]).
+    /// Unique tool name (max 64 chars, `[a-zA-Z0-9_-]`).
     pub name: String,
     /// Human-readable description shown to the model.
     pub description: String,


### PR DESCRIPTION
## Summary

- **Headline feature**: structured streaming output via `stream_object::<T>()` backed by a 1282-line stack-based partial JSON repairer. `generate_object::<T>()` also lands, with transparent tool-use fallback for providers without native structured output (Anthropic, Google).
- **Breaking API cleanup**: `ModelRef` newtype removed (use `String`), `ProviderKind` enum removed, `telemetry` feature flag removed (gated no code), `BuildProvider` sealed. Internal `Agent`/`AgentBuilder`/`RunTools` field mirror collapsed.
- **Reliability fixes**: `partial_json` rewritten as stack-based state machine, hardened against unicode escape truncation, root arrays supported; `stream_object` schema injection deduplicated, `type_name` sanitised, final buffer flushed on EOF; `cargo doc` broken intra-doc links to the (private) `ToolRegistry` cleared.
- **Docs**: README.md and README_CN.md fully rewritten as onboarding-flow narrative (Vue-inspired), 1:1 EN/CN H2/H3 line-number parity at 752 lines each. New runnable example: `examples/structured_streaming.rs`.
- `version` bumped 0.1.9 → 0.2.0; new `CHANGELOG.md`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 74 tests + doctests pass
- [x] `cargo doc --no-deps` — zero warnings (previously: 2 broken intra-doc links to `ToolRegistry`)
- [x] `cargo build --examples` — all 9 examples build, including the new `structured_streaming`
- [ ] Reviewer: read CHANGELOG.md breaking-changes list against own downstream usage
- [ ] Reviewer: spot-check README.md narrative flow (Introduction → Quick Start → Essentials → Production → Integration → Reference)
- [ ] Reviewer: confirm README_CN.md tracks EN translation faithfully (1:1 heading map, no drift in terminology)