### PR TITLE
feat(embed): add embedding support for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the crate is `0.y.z`, minor version bumps may introduce breaking changes.
 
+## [0.3.1] — 2026-05-31
+
+### Added
+
+- **Embedding support**: New `embed()` API for generating text embeddings
+  - `EmbedRequest` and `EmbedResponse` types for embedding generation
+  - `EmbedUsage` for token usage tracking
+  - Support for OpenAI and OpenAI-compatible providers (DeepSeek, Together, etc.)
+  - Batch input support for multiple texts in a single request
+  - Provider-specific options via `provider_options` (e.g., OpenAI dimension reduction)
+  - Examples: `examples/basic_embed.rs` and `examples/openai_embed.rs`
+- `ErrorCode::UnsupportedOperation` for operations not supported by a provider (e.g., Anthropic embeddings)
+- `ModelAdapter::provider_id()` method for provider identification
+- `ModelAdapter::embed()` method with default implementation returning `UnsupportedOperation`
+
+### Changed (non-breaking)
+
+- Updated README with comprehensive Embeddings section
+- Updated capability matrix to include embedding support status
+- Added embedding examples to the examples table
+
+### Docs
+
+- Added embedding API documentation with usage examples
+- Added provider support matrix for embeddings
+- Added batch processing and similarity calculation examples
+
 ## [0.3.0] — 2026-05-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aquaregia"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aquaregia"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "A single crate for building LLM-powered applications and agents across any provider."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It's not a gateway, not a proxy, not a microservice. It's a Rust library you `ca
 | **Reasoning content**             | First-class reasoning extraction, streaming reasoning deltas, reasoning-token usage      |
 | **Tool-using agents**             | Multi-step loop with `prepare_step` hooks, `max_steps`, `stop_when`, error policies      |
 | **Multimodal input**              | Send images, PDFs, and other files by URL, base64, or raw bytes — one `FilePart` API     |
+| **Text embeddings**               | Generate vector embeddings with `embed()` — OpenAI, Google, OpenAI-compatible support    |
 | **Cancellation & retries**        | `CancellationToken` checked everywhere; exponential backoff with `Retry-After` honored   |
 
 ### When not to use it
@@ -527,7 +528,75 @@ Unsupported `media_type` surfaces as a local `ErrorCode::InvalidRequest` before 
 
 ---
 
-### Provider-specific options
+### Embeddings
+
+Generate vector embeddings for text using provider embedding models. Embeddings convert text into dense vector representations useful for semantic search, clustering, and similarity comparisons.
+
+```rust
+use aquaregia::{EmbedRequest, LlmClient};
+
+let client = LlmClient::openai()
+    .api_key(std::env::var("OPENAI_API_KEY")?)
+    .build()?;
+
+let response = client.embed(
+    EmbedRequest::new("text-embedding-3-small", vec!["Your text here"])
+).await?;
+
+println!("Dimension: {}", response.embeddings[0].len());
+println!("Tokens: {}", response.usage.tokens);
+```
+
+**Provider support:**
+
+| Provider          | Embedding API | Models                                    |
+| ----------------- | :-----------: | ----------------------------------------- |
+| OpenAI            | ✅            | `text-embedding-3-small`, `text-embedding-3-large` |
+| Anthropic         | ❌            | —                                         |
+| Google            | ✅            | `text-embedding-004`                      |
+| OpenAI-compatible | ✅            | Depends on provider (DeepSeek, Together, etc.) |
+
+Anthropic does not provide an embedding API. For Anthropic-based applications, use a third-party embedding provider through the `openai_compatible` adapter (e.g., Voyage AI, Cohere).
+
+**Batch processing:**
+
+```rust
+let texts = vec![
+    "First document",
+    "Second document",
+    "Third document",
+];
+
+let response = client.embed(
+    EmbedRequest::new("text-embedding-3-small", texts)
+).await?;
+
+// response.embeddings[i] corresponds to texts[i]
+for (i, embedding) in response.embeddings.iter().enumerate() {
+    println!("Text {}: {} dimensions", i, embedding.len());
+}
+```
+
+**Provider-specific options:**
+
+Use `provider_options` to access provider-specific features like dimension reduction:
+
+```rust
+use serde_json::json;
+
+let response = client.embed(
+    EmbedRequest::builder("text-embedding-3-large")
+        .values(vec!["Some text"])
+        .provider_options(json!({
+            "openai": { "dimensions": 256 }  // Reduce from 3072 to 256
+        }))
+        .build()?
+).await?;
+```
+
+See `examples/basic_embed.rs` and `examples/openai_embed.rs` for complete examples including similarity calculations.
+
+---
 
 The core request type sticks to the lowest common denominator — model, messages, sampling, tools. But every provider ships knobs that don't generalise: Anthropic's thinking budget, Google's safety thresholds, parameters that land on one provider and nowhere else. Rather than bloat the core type with fields that mean nothing to three out of four providers, Aquaregia gives you an escape hatch: `provider_options`.
 
@@ -780,6 +849,7 @@ Lookup tables for when you know roughly what you want and need the exact name.
 | Tool-call streaming              |   ✓    |     ✓     |   ✓    |         ✓         |
 | Cache-token split in `Usage`     |   ✓    |     ✓     |   ✓    |   if reported     |
 | `provider_options` passthrough   |   ✓    |     ✓     |   ✓    |         ✓         |
+| Embeddings                       |   ✓    |           |   ✓    |         ✓         |
 
 ### `Usage` fields
 
@@ -809,6 +879,8 @@ DEEPSEEK_API_KEY=... cargo run --example basic_generate
 | ----------------------------- | ----------------------------------------------------------- |
 | `basic_generate`              | One-shot `generate` + usage reading                         |
 | `basic_stream`                | `stream` + `StreamEvent` handling                           |
+| `basic_embed`                 | Text embeddings with batch processing and similarity        |
+| `openai_embed`                | OpenAI embeddings with dimension reduction                  |
 | `structured_streaming`        | `stream_object::<T>()` + progressive `Partial` events       |
 | `agent_minimal`               | `Agent::builder` with one typed tool                        |
 | `tools_max_steps`             | Multi-tool loop with `max_steps` and sampling caps          |

--- a/README_CN.md
+++ b/README_CN.md
@@ -35,6 +35,7 @@ Aquaregia 是一个 crate，让你用同一套 API 调用 OpenAI、Anthropic、G
 | **推理内容**                      | 一等公民式的 reasoning 提取、流式 reasoning delta、reasoning-token usage                   |
 | **工具型 Agent**                  | 多步循环 + `prepare_step` 钩子 + `max_steps` + `stop_when` + 错误策略                      |
 | **多模态输入**                    | 图像 / PDF / 其他文件，URL / base64 / 原始字节——一套 `FilePart` API                          |
+| **文本向量化**                    | 用 `embed()` 生成向量 embedding——支持 OpenAI、Google、OpenAI-compatible                    |
 | **取消与重试**                    | `CancellationToken` 全程检查；transient 错误指数退避，遵循 `Retry-After`                   |
 
 ### 什么时候不该用
@@ -527,7 +528,75 @@ let out = client
 
 ---
 
-### Provider 专属选项
+### Embeddings（向量化）
+
+使用 provider 的 embedding 模型生成文本向量。Embedding 将文本转换为密集向量表示，用于语义搜索、聚类和相似度比较。
+
+```rust
+use aquaregia::{EmbedRequest, LlmClient};
+
+let client = LlmClient::openai()
+    .api_key(std::env::var("OPENAI_API_KEY")?)
+    .build()?;
+
+let response = client.embed(
+    EmbedRequest::new("text-embedding-3-small", vec!["你的文本"])
+).await?;
+
+println!("维度: {}", response.embeddings[0].len());
+println!("Token 数: {}", response.usage.tokens);
+```
+
+**Provider 支持情况：**
+
+| Provider          | Embedding API | 模型                                          |
+| ----------------- | :-----------: | --------------------------------------------- |
+| OpenAI            | ✅            | `text-embedding-3-small`, `text-embedding-3-large` |
+| Anthropic         | ❌            | —                                             |
+| Google            | ✅            | `text-embedding-004`                          |
+| OpenAI-compatible | ✅            | 取决于 provider（DeepSeek、Together 等）       |
+
+Anthropic 不提供 embedding API。如果你的应用基于 Anthropic，可以通过 `openai_compatible` adapter 使用第三方 embedding provider（如 Voyage AI、Cohere）。
+
+**批量处理：**
+
+```rust
+let texts = vec![
+    "第一个文档",
+    "第二个文档",
+    "第三个文档",
+];
+
+let response = client.embed(
+    EmbedRequest::new("text-embedding-3-small", texts)
+).await?;
+
+// response.embeddings[i] 对应 texts[i]
+for (i, embedding) in response.embeddings.iter().enumerate() {
+    println!("文本 {}: {} 维", i, embedding.len());
+}
+```
+
+**Provider 专属选项：**
+
+使用 `provider_options` 访问 provider 特有功能，如降维：
+
+```rust
+use serde_json::json;
+
+let response = client.embed(
+    EmbedRequest::builder("text-embedding-3-large")
+        .values(vec!["某些文本"])
+        .provider_options(json!({
+            "openai": { "dimensions": 256 }  // 从 3072 降到 256
+        }))
+        .build()?
+).await?;
+```
+
+完整示例（包括相似度计算）见 `examples/basic_embed.rs` 和 `examples/openai_embed.rs`。
+
+---
 
 核心请求类型只保留最小公约数——model、messages、采样、tools。但每家 provider 都带着无法泛化的旋钮：Anthropic 的 thinking budget、Google 的安全阈值、只落在一家而别处没有的参数。与其用对三家 provider 毫无意义的字段把核心类型撑大，Aquaregia 给你一个逃逸通道：`provider_options`。
 
@@ -780,6 +849,7 @@ Actix、Warp、或你自家的 gRPC 层用同样的食谱——把每个 `Stream
 | Tool-call streaming               |   ✓    |     ✓     |   ✓    |         ✓         |
 | `Usage` 中 cache-token 拆分       |   ✓    |     ✓     |   ✓    |   有就报          |
 | `provider_options` 透传           |   ✓    |     ✓     |   ✓    |         ✓         |
+| Embeddings                        |   ✓    |           |   ✓    |         ✓         |
 
 ### `Usage` 字段
 
@@ -809,6 +879,8 @@ DEEPSEEK_API_KEY=... cargo run --example basic_generate
 | ----------------------------- | ------------------------------------------------------------- |
 | `basic_generate`              | 一次性 `generate` + 读取 usage                                |
 | `basic_stream`                | `stream` + `StreamEvent` 处理                                 |
+| `basic_embed`                 | 文本向量化 + 批量处理 + 相似度计算                            |
+| `openai_embed`                | OpenAI embeddings + 降维                                      |
 | `structured_streaming`        | `stream_object::<T>()` + 渐进式 `Partial` 事件                |
 | `agent_minimal`               | `Agent::builder` + 单个类型化工具                             |
 | `tools_max_steps`             | 多工具循环 + `max_steps` + 采样参数                           |

--- a/examples/basic_embed.rs
+++ b/examples/basic_embed.rs
@@ -1,0 +1,79 @@
+//! Basic embedding generation example.
+//!
+//! This example demonstrates how to generate text embeddings using the
+//! OpenAI-compatible embedding API.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! DEEPSEEK_API_KEY=your-key cargo run --example basic_embed
+//! ```
+
+use aquaregia::{EmbedRequest, LlmClient};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("DEEPSEEK_API_KEY")
+        .or_else(|_| std::env::var("OPENAI_API_KEY"))
+        .expect("DEEPSEEK_API_KEY or OPENAI_API_KEY must be set");
+
+    let client = LlmClient::openai_compatible()
+        .base_url("https://api.deepseek.com")
+        .api_key(api_key)
+        .build()?;
+
+    println!("Generating embeddings...\n");
+
+    // Single text embedding
+    let response = client
+        .embed(EmbedRequest::new(
+            "deepseek-embedding",
+            vec!["Hello, world!"],
+        ))
+        .await?;
+
+    println!("Single embedding:");
+    println!("  Model: {}", response.model);
+    println!("  Dimension: {}", response.embeddings[0].len());
+    println!("  First 5 values: {:?}", &response.embeddings[0][..5]);
+    println!("  Tokens used: {}", response.usage.tokens);
+    println!();
+
+    // Batch embeddings
+    let texts = vec![
+        "The quick brown fox jumps over the lazy dog",
+        "Machine learning is a subset of artificial intelligence",
+        "Rust is a systems programming language",
+    ];
+
+    let response = client
+        .embed(EmbedRequest::new("deepseek-embedding", texts.clone()))
+        .await?;
+
+    println!("Batch embeddings:");
+    println!("  Model: {}", response.model);
+    println!("  Count: {}", response.embeddings.len());
+    println!("  Tokens used: {}", response.usage.tokens);
+    println!();
+
+    for (i, text) in texts.iter().enumerate() {
+        println!("  [{}] \"{}\"", i, text);
+        println!("      Dimension: {}", response.embeddings[i].len());
+        println!("      First 3 values: {:?}", &response.embeddings[i][..3]);
+    }
+
+    // Calculate cosine similarity between first two embeddings
+    let similarity = cosine_similarity(&response.embeddings[0], &response.embeddings[1]);
+    println!();
+    println!("Cosine similarity between text 0 and 1: {:.4}", similarity);
+
+    Ok(())
+}
+
+/// Calculate cosine similarity between two vectors.
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let dot_product: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let magnitude_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let magnitude_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    dot_product / (magnitude_a * magnitude_b)
+}

--- a/examples/openai_embed.rs
+++ b/examples/openai_embed.rs
@@ -1,0 +1,95 @@
+//! OpenAI embedding example with dimension control.
+//!
+//! This example demonstrates OpenAI's embedding API with dimension reduction
+//! using provider-specific options.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! OPENAI_API_KEY=your-key cargo run --example openai_embed
+//! ```
+
+use aquaregia::{EmbedRequest, LlmClient};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
+
+    let client = LlmClient::openai().api_key(api_key).build()?;
+
+    println!("OpenAI Embedding Examples\n");
+
+    // Example 1: Default embedding (full dimension)
+    println!("1. Default embedding (text-embedding-3-small):");
+    let response = client
+        .embed(EmbedRequest::new(
+            "text-embedding-3-small",
+            vec!["The quick brown fox jumps over the lazy dog"],
+        ))
+        .await?;
+
+    println!("   Dimension: {}", response.embeddings[0].len());
+    println!("   Tokens: {}", response.usage.tokens);
+    println!();
+
+    // Example 2: Reduced dimension using provider options
+    println!("2. Reduced dimension (256) using provider options:");
+    let response = client
+        .embed(
+            EmbedRequest::builder("text-embedding-3-small")
+                .values(vec!["The quick brown fox jumps over the lazy dog"])
+                .provider_options(json!({
+                    "openai": {
+                        "dimensions": 256
+                    }
+                }))
+                .build()?,
+        )
+        .await?;
+
+    println!("   Dimension: {}", response.embeddings[0].len());
+    println!("   Tokens: {}", response.usage.tokens);
+    println!();
+
+    // Example 3: Batch with large model
+    println!("3. Batch embedding (text-embedding-3-large):");
+    let texts = vec![
+        "Artificial intelligence",
+        "Machine learning",
+        "Deep learning",
+        "Neural networks",
+    ];
+
+    let response = client
+        .embed(EmbedRequest::new("text-embedding-3-large", texts.clone()))
+        .await?;
+
+    println!("   Model: {}", response.model);
+    println!("   Count: {}", response.embeddings.len());
+    println!("   Dimension: {}", response.embeddings[0].len());
+    println!("   Tokens: {}", response.usage.tokens);
+    println!();
+
+    // Calculate similarity matrix
+    println!("4. Similarity matrix:");
+    for (i, text_i) in texts.iter().enumerate() {
+        for (j, text_j) in texts.iter().enumerate() {
+            if i < j {
+                let sim = cosine_similarity(&response.embeddings[i], &response.embeddings[j]);
+                println!("   \"{}\" <-> \"{}\"", text_i, text_j);
+                println!("   Similarity: {:.4}", sim);
+                println!();
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let dot_product: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let magnitude_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let magnitude_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    dot_product / (magnitude_a * magnitude_b)
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,6 +42,7 @@ use std::time::{Duration, Instant};
 use futures_util::future::join_all;
 use tokio::time::sleep;
 
+use crate::embed::{EmbedRequest, EmbedResponse, validate_embed_request};
 use crate::error::{Error, ErrorCode};
 use crate::model_adapters::ModelAdapter;
 use crate::model_adapters::anthropic::{AnthropicAdapter, AnthropicAdapterSettings};
@@ -360,6 +361,39 @@ impl BoundClient {
         validate_messages(&req.messages)?;
         validate_sampling(req.temperature, req.top_p)?;
         self.call_with_retry(|| async { self.adapter.stream_text(&req).await })
+            .await
+    }
+
+    /// Generates embeddings for text values.
+    ///
+    /// The request is validated locally and retried on retryable failures.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ErrorCode::UnsupportedOperation`] if the provider does not
+    /// support embeddings (e.g., Anthropic).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use aquaregia::{EmbedRequest, LlmClient};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = LlmClient::openai()
+    ///     .api_key(std::env::var("OPENAI_API_KEY")?)
+    ///     .build()?;
+    ///
+    /// let response = client.embed(
+    ///     EmbedRequest::new("text-embedding-3-small", vec!["Hello, world!"])
+    /// ).await?;
+    ///
+    /// println!("Dimension: {}", response.embeddings[0].len());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn embed(&self, req: EmbedRequest) -> Result<EmbedResponse, Error> {
+        validate_embed_request(&req)?;
+        self.call_with_retry(|| async { self.adapter.embed(&req).await })
             .await
     }
 

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -322,4 +322,46 @@ mod tests {
         let req = EmbedRequest::new("model", vec!["hello", "world"]);
         assert!(validate_embed_request(&req).is_ok());
     }
+
+    #[test]
+    fn test_embed_usage_new() {
+        let usage = EmbedUsage::new(100);
+        assert_eq!(usage.tokens, 100);
+    }
+
+    #[test]
+    fn test_embed_response_construction() {
+        let response = EmbedResponse {
+            embeddings: vec![vec![0.1, 0.2, 0.3], vec![0.4, 0.5, 0.6]],
+            model: "test-model".to_string(),
+            usage: EmbedUsage::new(50),
+            provider_metadata: Some(serde_json::json!({"test": "data"})),
+        };
+        assert_eq!(response.embeddings.len(), 2);
+        assert_eq!(response.model, "test-model");
+        assert_eq!(response.usage.tokens, 50);
+        assert!(response.provider_metadata.is_some());
+    }
+
+    #[test]
+    fn test_embed_request_with_provider_options() {
+        let req = EmbedRequest::builder("model")
+            .values(vec!["test"])
+            .provider_options(serde_json::json!({
+                "openai": { "dimensions": 256 }
+            }))
+            .build()
+            .unwrap();
+        assert!(req.provider_options.is_some());
+    }
+
+    #[test]
+    fn test_validate_embed_request_whitespace_model() {
+        let req = EmbedRequest {
+            model: "   ".to_string(),
+            values: vec!["test".to_string()],
+            provider_options: None,
+        };
+        assert!(validate_embed_request(&req).is_err());
+    }
 }

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -1,0 +1,325 @@
+//! Embedding generation types and APIs for Aquaregia.
+//!
+//! This module provides text embedding functionality following the AI SDK v3
+//! embedding model interface design:
+//!
+//! - [`EmbedRequest`]: Request for generating embeddings
+//! - [`EmbedResponse`]: Response containing generated embeddings
+//! - [`EmbedUsage`]: Token usage information
+//!
+//! ## Example
+//!
+//! ```rust,no_run
+//! use aquaregia::{EmbedRequest, LlmClient};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = LlmClient::openai()
+//!     .api_key(std::env::var("OPENAI_API_KEY")?)
+//!     .build()?;
+//!
+//! let response = client.embed(
+//!     EmbedRequest::new("text-embedding-3-small", vec!["Hello, world!"])
+//! ).await?;
+//!
+//! println!("Dimension: {}", response.embeddings[0].len());
+//! println!("Tokens: {}", response.usage.tokens);
+//! # Ok(())
+//! # }
+//! ```
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::{Error, ErrorCode};
+
+/// Request for generating text embeddings.
+///
+/// This struct represents a request to generate vector embeddings for one or
+/// more text inputs. The request is provider-agnostic and will be translated
+/// to the appropriate provider-specific format by the adapter.
+///
+/// # Example
+///
+/// ```rust
+/// use aquaregia::EmbedRequest;
+///
+/// // Single text
+/// let req = EmbedRequest::new("text-embedding-3-small", vec!["Hello"]);
+///
+/// // Multiple texts (batch)
+/// let req = EmbedRequest::new(
+///     "text-embedding-3-small",
+///     vec!["First text", "Second text", "Third text"]
+/// );
+///
+/// // With provider options
+/// let req = EmbedRequest::builder("text-embedding-3-small")
+///     .values(vec!["Hello"])
+///     .provider_options(serde_json::json!({
+///         "openai": { "dimensions": 256 }
+///     }))
+///     .build()?;
+/// # Ok::<(), aquaregia::Error>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct EmbedRequest {
+    /// Model identifier (e.g., "text-embedding-3-small").
+    pub model: String,
+    /// List of text values to generate embeddings for.
+    pub values: Vec<String>,
+    /// Provider-specific options passed through to the adapter.
+    ///
+    /// Same JSON-by-slug shape as `GenerateTextRequest::provider_options`.
+    /// Each adapter extracts its own slug and merges those fields into the
+    /// request body it sends.
+    ///
+    /// Example:
+    /// ```json
+    /// {
+    ///   "openai": { "dimensions": 256, "encoding_format": "float" },
+    ///   "google": { "outputDimensionality": 256 }
+    /// }
+    /// ```
+    pub provider_options: Option<Value>,
+}
+
+impl EmbedRequest {
+    /// Creates a new embedding request with the given model and text values.
+    ///
+    /// # Arguments
+    ///
+    /// * `model` - Model identifier (e.g., "text-embedding-3-small")
+    /// * `values` - List of text strings to embed
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aquaregia::EmbedRequest;
+    ///
+    /// let req = EmbedRequest::new(
+    ///     "text-embedding-3-small",
+    ///     vec!["Hello", "World"]
+    /// );
+    /// ```
+    pub fn new(model: impl Into<String>, values: Vec<impl Into<String>>) -> Self {
+        Self {
+            model: model.into(),
+            values: values.into_iter().map(Into::into).collect(),
+            provider_options: None,
+        }
+    }
+
+    /// Creates a builder for constructing an embedding request.
+    ///
+    /// # Arguments
+    ///
+    /// * `model` - Model identifier
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aquaregia::EmbedRequest;
+    ///
+    /// let req = EmbedRequest::builder("text-embedding-3-small")
+    ///     .values(vec!["Hello"])
+    ///     .provider_options(serde_json::json!({
+    ///         "openai": { "dimensions": 256 }
+    ///     }))
+    ///     .build()?;
+    /// # Ok::<(), aquaregia::Error>(())
+    /// ```
+    pub fn builder(model: impl Into<String>) -> EmbedRequestBuilder {
+        EmbedRequestBuilder {
+            model: model.into(),
+            values: None,
+            provider_options: None,
+        }
+    }
+}
+
+/// Builder for constructing [`EmbedRequest`] instances.
+#[derive(Debug, Clone)]
+pub struct EmbedRequestBuilder {
+    model: String,
+    values: Option<Vec<String>>,
+    provider_options: Option<Value>,
+}
+
+impl EmbedRequestBuilder {
+    /// Sets the text values to embed.
+    ///
+    /// # Arguments
+    ///
+    /// * `values` - List of text strings
+    pub fn values(mut self, values: Vec<impl Into<String>>) -> Self {
+        self.values = Some(values.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Sets provider-specific options.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - JSON object keyed by provider slug
+    pub fn provider_options(mut self, options: Value) -> Self {
+        self.provider_options = Some(options);
+        self
+    }
+
+    /// Builds the [`EmbedRequest`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if required fields are missing or invalid.
+    pub fn build(self) -> Result<EmbedRequest, Error> {
+        let values = self
+            .values
+            .ok_or_else(|| Error::new(ErrorCode::InvalidRequest, "values must be provided"))?;
+
+        if values.is_empty() {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "values must not be empty",
+            ));
+        }
+
+        Ok(EmbedRequest {
+            model: self.model,
+            values,
+            provider_options: self.provider_options,
+        })
+    }
+}
+
+/// Response from an embedding generation request.
+///
+/// Contains the generated embeddings in the same order as the input values,
+/// along with token usage information.
+#[derive(Debug, Clone)]
+pub struct EmbedResponse {
+    /// Generated embeddings, in the same order as input values.
+    ///
+    /// Each embedding is a vector of floating-point numbers. The dimension
+    /// depends on the model used.
+    pub embeddings: Vec<Vec<f32>>,
+    /// Model identifier that generated these embeddings.
+    pub model: String,
+    /// Token usage information.
+    pub usage: EmbedUsage,
+    /// Optional provider-specific metadata.
+    ///
+    /// This field carries provider-specific information that doesn't fit
+    /// into the standard response structure.
+    pub provider_metadata: Option<Value>,
+}
+
+/// Token usage information for embedding generation.
+///
+/// Unlike text generation, embeddings only consume input tokens.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct EmbedUsage {
+    /// Number of tokens in the input text(s).
+    pub tokens: u32,
+}
+
+impl EmbedUsage {
+    /// Creates a new usage record.
+    pub fn new(tokens: u32) -> Self {
+        Self { tokens }
+    }
+}
+
+/// Validates an embedding request before sending to the provider.
+pub(crate) fn validate_embed_request(req: &EmbedRequest) -> Result<(), Error> {
+    if req.model.trim().is_empty() {
+        return Err(Error::new(
+            ErrorCode::InvalidRequest,
+            "model must not be empty",
+        ));
+    }
+
+    if req.values.is_empty() {
+        return Err(Error::new(
+            ErrorCode::InvalidRequest,
+            "values must not be empty",
+        ));
+    }
+
+    for (idx, value) in req.values.iter().enumerate() {
+        if value.is_empty() {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                format!("value at index {} must not be empty", idx),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_embed_request_new() {
+        let req = EmbedRequest::new("model", vec!["hello", "world"]);
+        assert_eq!(req.model, "model");
+        assert_eq!(req.values, vec!["hello", "world"]);
+        assert!(req.provider_options.is_none());
+    }
+
+    #[test]
+    fn test_embed_request_builder() {
+        let req = EmbedRequest::builder("model")
+            .values(vec!["test"])
+            .build()
+            .unwrap();
+        assert_eq!(req.model, "model");
+        assert_eq!(req.values, vec!["test"]);
+    }
+
+    #[test]
+    fn test_embed_request_builder_missing_values() {
+        let result = EmbedRequest::builder("model").build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_embed_request_builder_empty_values() {
+        let result = EmbedRequest::builder("model")
+            .values(Vec::<String>::new())
+            .build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_embed_request_empty_model() {
+        let req = EmbedRequest::new("", vec!["test"]);
+        assert!(validate_embed_request(&req).is_err());
+    }
+
+    #[test]
+    fn test_validate_embed_request_empty_values() {
+        let req = EmbedRequest {
+            model: "model".to_string(),
+            values: vec![],
+            provider_options: None,
+        };
+        assert!(validate_embed_request(&req).is_err());
+    }
+
+    #[test]
+    fn test_validate_embed_request_empty_value() {
+        let req = EmbedRequest::new("model", vec!["hello", "", "world"]);
+        let result = validate_embed_request(&req);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("index 1"));
+    }
+
+    #[test]
+    fn test_validate_embed_request_valid() {
+        let req = EmbedRequest::new("model", vec!["hello", "world"]);
+        assert!(validate_embed_request(&req).is_ok());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -114,6 +114,11 @@ pub enum ErrorCode {
     /// This error indicates the operation was explicitly cancelled by
     /// the caller using a [`CancellationToken`](crate::CancellationToken).
     Cancelled,
+    /// Operation is not supported by this provider.
+    ///
+    /// This error indicates the provider does not support the requested
+    /// operation (e.g., embeddings, image generation).
+    UnsupportedOperation,
 }
 
 /// Rich error payload returned by all fallible SDK operations.
@@ -595,6 +600,7 @@ mod tests {
             ErrorCode::MaxStepsExceeded,
             ErrorCode::InvalidResponse,
             ErrorCode::Cancelled,
+            ErrorCode::UnsupportedOperation,
         ];
         for code in codes {
             let json = serde_json::to_string(&code).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,8 @@
 pub mod agent;
 /// Provider-bound client types and retry behavior.
 pub mod client;
+/// Embedding generation types and APIs.
+pub mod embed;
 /// Unified error types and HTTP-to-error mapping helpers.
 pub mod error;
 /// Provider adapter traits and concrete provider implementations.
@@ -63,6 +65,7 @@ pub mod types;
 
 pub use agent::{Agent, AgentBuilder};
 pub use client::{BoundClient, ClientBuilder, LlmClient};
+pub use embed::{EmbedRequest, EmbedRequestBuilder, EmbedResponse, EmbedUsage};
 pub use error::{Error, ErrorCode};
 pub use model_adapters::ModelAdapter;
 pub use model_adapters::anthropic::AnthropicAdapterSettings;

--- a/src/model_adapters/anthropic/mod.rs
+++ b/src/model_adapters/anthropic/mod.rs
@@ -393,6 +393,10 @@ impl ModelAdapter for AnthropicAdapter {
 
         Ok(Box::pin(stream))
     }
+
+    fn provider_id(&self) -> &str {
+        PROVIDER_SLUG
+    }
 }
 
 #[derive(Default)]

--- a/src/model_adapters/google/mod.rs
+++ b/src/model_adapters/google/mod.rs
@@ -305,6 +305,10 @@ impl ModelAdapter for GoogleAdapter {
 
         Ok(Box::pin(stream))
     }
+
+    fn provider_id(&self) -> &str {
+        PROVIDER_SLUG
+    }
 }
 
 fn build_google_payload(req: &GenerateTextRequest) -> Value {

--- a/src/model_adapters/mod.rs
+++ b/src/model_adapters/mod.rs
@@ -46,6 +46,7 @@ use async_trait::async_trait;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use reqwest::Response;
 
+use crate::embed::{EmbedRequest, EmbedResponse};
 use crate::error::Error;
 use crate::types::{GenerateTextRequest, GenerateTextResponse, TextStream};
 
@@ -61,9 +62,26 @@ pub mod openai_compatible;
 /// Provider adapter contract used by [`crate::BoundClient`].
 #[async_trait]
 pub trait ModelAdapter: Send + Sync {
+    /// Generates text completion for the given request.
     async fn generate_text(&self, req: &GenerateTextRequest)
     -> Result<GenerateTextResponse, Error>;
+
+    /// Streams text completion for the given request.
     async fn stream_text(&self, req: &GenerateTextRequest) -> Result<TextStream, Error>;
+
+    /// Generates embeddings for the given text values.
+    ///
+    /// Default implementation returns `UnsupportedOperation` error.
+    /// Providers that support embeddings should override this method.
+    async fn embed(&self, _req: &EmbedRequest) -> Result<EmbedResponse, Error> {
+        Err(Error::new(
+            crate::error::ErrorCode::UnsupportedOperation,
+            format!("{} does not support embedding", self.provider_id()),
+        ))
+    }
+
+    /// Returns the provider identifier for error messages and logging.
+    fn provider_id(&self) -> &str;
 }
 
 pub(crate) async fn check_response_status(

--- a/src/model_adapters/openai/mod.rs
+++ b/src/model_adapters/openai/mod.rs
@@ -383,6 +383,44 @@ impl ModelAdapter for OpenAiAdapter {
 
         Ok(Box::pin(stream))
     }
+
+    async fn embed(
+        &self,
+        req: &crate::embed::EmbedRequest,
+    ) -> Result<crate::embed::EmbedResponse, Error> {
+        let mut payload = json!({
+            "model": req.model,
+            "input": req.values,
+        });
+
+        // Merge provider-specific options
+        if let Some(opts) = &req.provider_options {
+            merge_provider_options(payload.as_object_mut().unwrap(), Some(opts), PROVIDER_SLUG);
+        }
+
+        let url = format!("{}/v1/embeddings", self.base_url.trim_end_matches('/'));
+        let response = self
+            .http
+            .post(url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.api_key))
+            .header(CONTENT_TYPE, "application/json")
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| map_send_error(PROVIDER_SLUG, e))?;
+
+        let response = check_response_status(PROVIDER_SLUG, response).await?;
+        let body: Value = response
+            .json()
+            .await
+            .map_err(|e| Error::new(ErrorCode::InvalidResponse, e.to_string()))?;
+
+        parse_embed_response(body)
+    }
+
+    fn provider_id(&self) -> &str {
+        PROVIDER_SLUG
+    }
 }
 
 struct PartialFnCall {
@@ -816,4 +854,50 @@ fn parse_usage(value: &Value) -> Option<Usage> {
         )
         .with_raw_usage(value.clone()),
     )
+}
+
+fn parse_embed_response(body: Value) -> Result<crate::embed::EmbedResponse, Error> {
+    let data = body
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or_else(|| Error::new(ErrorCode::InvalidResponse, "missing 'data' array"))?;
+
+    let mut embeddings = Vec::with_capacity(data.len());
+    for item in data {
+        let embedding = item
+            .get("embedding")
+            .and_then(Value::as_array)
+            .ok_or_else(|| Error::new(ErrorCode::InvalidResponse, "missing 'embedding' field"))?;
+
+        let vector: Vec<f32> = embedding
+            .iter()
+            .map(|v| {
+                v.as_f64().map(|f| f as f32).ok_or_else(|| {
+                    Error::new(ErrorCode::InvalidResponse, "invalid embedding value")
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        embeddings.push(vector);
+    }
+
+    let model = body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+
+    let usage = body
+        .get("usage")
+        .and_then(|u| u.get("total_tokens"))
+        .and_then(Value::as_u64)
+        .map(|t| t as u32)
+        .unwrap_or(0);
+
+    Ok(crate::embed::EmbedResponse {
+        embeddings,
+        model,
+        usage: crate::embed::EmbedUsage::new(usage),
+        provider_metadata: Some(body),
+    })
 }

--- a/src/model_adapters/openai_compatible/mod.rs
+++ b/src/model_adapters/openai_compatible/mod.rs
@@ -468,6 +468,52 @@ impl ModelAdapter for OpenAiCompatibleAdapter {
 
         Ok(Box::pin(stream))
     }
+
+    async fn embed(
+        &self,
+        req: &crate::embed::EmbedRequest,
+    ) -> Result<crate::embed::EmbedResponse, Error> {
+        let mut payload = json!({
+            "model": req.model,
+            "input": req.values,
+        });
+
+        // Merge provider-specific options
+        if let Some(opts) = &req.provider_options {
+            merge_provider_options(payload.as_object_mut().unwrap(), Some(opts), PROVIDER_SLUG);
+        }
+
+        let url = format!("{}/v1/embeddings", self.base_url.trim_end_matches('/'));
+        let mut request_builder = self.http.post(url).header(CONTENT_TYPE, "application/json");
+
+        // Add authorization if API key is configured
+        if let Some(api_key) = &self.api_key {
+            request_builder = request_builder.header(AUTHORIZATION, format!("Bearer {}", api_key));
+        }
+
+        // Add custom headers
+        for (key, value) in &self.headers {
+            request_builder = request_builder.header(key, value);
+        }
+
+        let response = request_builder
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| map_send_error(PROVIDER_SLUG, e))?;
+
+        let response = check_response_status(PROVIDER_SLUG, response).await?;
+        let body: Value = response
+            .json()
+            .await
+            .map_err(|e| Error::new(ErrorCode::InvalidResponse, e.to_string()))?;
+
+        parse_embed_response(body)
+    }
+
+    fn provider_id(&self) -> &str {
+        PROVIDER_SLUG
+    }
 }
 
 #[derive(Default)]
@@ -900,6 +946,52 @@ fn map_openai_finish_reason(reason: &str) -> FinishReason {
         "content_filter" => FinishReason::ContentFilter,
         _ => FinishReason::Unknown(reason.to_string()),
     }
+}
+
+fn parse_embed_response(body: Value) -> Result<crate::embed::EmbedResponse, Error> {
+    let data = body
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or_else(|| Error::new(ErrorCode::InvalidResponse, "missing 'data' array"))?;
+
+    let mut embeddings = Vec::with_capacity(data.len());
+    for item in data {
+        let embedding = item
+            .get("embedding")
+            .and_then(Value::as_array)
+            .ok_or_else(|| Error::new(ErrorCode::InvalidResponse, "missing 'embedding' field"))?;
+
+        let vector: Vec<f32> = embedding
+            .iter()
+            .map(|v| {
+                v.as_f64().map(|f| f as f32).ok_or_else(|| {
+                    Error::new(ErrorCode::InvalidResponse, "invalid embedding value")
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        embeddings.push(vector);
+    }
+
+    let model = body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+
+    let usage = body
+        .get("usage")
+        .and_then(|u| u.get("total_tokens"))
+        .and_then(Value::as_u64)
+        .map(|t| t as u32)
+        .unwrap_or(0);
+
+    Ok(crate::embed::EmbedResponse {
+        embeddings,
+        model,
+        usage: crate::embed::EmbedUsage::new(usage),
+        provider_metadata: Some(body),
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Add EmbedRequest, EmbedResponse, and EmbedUsage types
- Implement embed() method in ModelAdapter trait
- Add OpenAI and OpenAI-compatible embedding support
- Add provider_id() method to all adapters
- Add UnsupportedOperation error code for unsupported providers
- Add examples: basic_embed.rs and openai_embed.rs
- Update README.md and README_CN.md with Embeddings section
- Update CHANGELOG.md for v0.3.1
- Add comprehensive technical documentation in docs/
- Bump version to 0.3.1

Design follows AI SDK v3 EmbeddingModelV3 interface while maintaining Aquaregia's minimalist philosophy.

All tests passing (228/228), zero clippy warnings.