### PR TITLE
Update product positioning language

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aquaregia"
 version = "0.3.3"
 edition = "2024"
-description = "A lightweight agent SDK for Rust: build tool-using LLM agents that run on any provider."
+description = "A lightweight Rust library for building tool-using LLM agents."
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/minorcell/aquaregia"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Aquaregia
 
-**A lightweight agent SDK for Rust.**
+**A lightweight Rust library for building tool-using LLM agents.**
 
 [![Crates.io](https://img.shields.io/crates/v/aquaregia.svg)](https://crates.io/crates/aquaregia)
 [![Docs.rs](https://docs.rs/aquaregia/badge.svg)](https://docs.rs/aquaregia)
@@ -145,7 +145,7 @@ let client = openai_compatible::Client::builder()
     .base_url("https://api.example.com")
     .api_key_from_env("OPENAI_COMPATIBLE_API_KEY")
     .header("x-trace-source", "aquaregia")
-    .query_param("source", "sdk")
+    .query_param("source", "library")
     .chat_completions_path("/v1/chat/completions")
     .build()?;
 ```

--- a/docs/content/docs/direct-requests.mdx
+++ b/docs/content/docs/direct-requests.mdx
@@ -24,7 +24,7 @@ let client = openai::Client::from_env()?;
 let response = client
     .generate(ChatRequest::from_prompt(
         "gpt-5.5",
-        "Write a concise release note for this SDK change.",
+        "Write a concise release note for this library change.",
     ))
     .await?;
 

--- a/docs/content/docs/embeddings.mdx
+++ b/docs/content/docs/embeddings.mdx
@@ -36,7 +36,7 @@ Batch related texts in one request when your provider quota and payload size all
 let req = EmbedRequest::new(
     "text-embedding-3-large",
     vec![
-        "Rust agent SDK",
+        "Rust agent library",
         "tool calling",
         "structured output",
     ],

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: Build provider-backed LLM agents in Rust.
 ---
 
-Aquaregia is a Rust SDK for applications that need an LLM to do work, not just return one completion.
+Aquaregia is a lightweight Rust library for building tool-using LLM agents.
 
 The common shape is:
 

--- a/docs/content/docs/provider-options.mdx
+++ b/docs/content/docs/provider-options.mdx
@@ -151,4 +151,4 @@ Aquaregia treats provider options as an escape hatch:
 - it does not reconcile conflicts when an option overwrites a field Aquaregia generated
 - it preserves the common API by keeping provider-specific concepts out of core types
 
-When a feature becomes portable across providers, it can move into the common request shape. Until then, prefer `provider_options` over adding provider-specific SDK types.
+When a feature becomes portable across providers, it can move into the common request shape. Until then, prefer `provider_options` over adding provider-specific library types.

--- a/docs/content/docs/providers.mdx
+++ b/docs/content/docs/providers.mdx
@@ -106,7 +106,7 @@ All hosted provider builders also support:
 | `timeout(Duration)` | a request should fail after a bounded time |
 | `max_retries(u8)` | retryable provider, transport, and timeout failures should be retried by the client |
 | `default_max_steps(u32)` | agents built from the client should inherit a tool-loop cap |
-| `user_agent(...)` | your application needs a custom SDK `User-Agent` suffix/value |
+| `user_agent(...)` | your application needs a custom Aquaregia `User-Agent` suffix/value |
 
 ## Use an OpenAI-compatible gateway
 
@@ -148,7 +148,7 @@ let client = openai_compatible::Client::builder()
     .base_url("https://api.example.com")
     .api_key_from_env("OPENAI_COMPATIBLE_API_KEY")
     .header("x-trace-source", "aquaregia")
-    .query_param("source", "sdk")
+    .query_param("source", "library")
     .build()?;
 ```
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -90,7 +90,7 @@ let client = openai::Client::from_env()?;
 let response = client
     .generate(ChatRequest::from_prompt(
         "gpt-5.5",
-        "Write a short release note for a Rust SDK.",
+        "Write a short release note for a Rust library.",
     ))
     .await?;
 

--- a/src/adapters/openai/mod.rs
+++ b/src/adapters/openai/mod.rs
@@ -141,7 +141,7 @@ impl ModelAdapter for OpenAiAdapter {
             // Indexed by output_index from the streaming events.
             let mut fn_partials: BTreeMap<u64, PartialFnCall> = BTreeMap::new();
             // Reasoning blocks keyed by output_index. Multiple `reasoning` items can
-            // appear in one response; the canonical id is `rs_*` from the SDK.
+            // appear in one response; the canonical id is `rs_*` from the API.
             let mut reasoning_blocks: BTreeMap<u64, String> = BTreeMap::new();
             let mut saw_tool_call = false;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -156,7 +156,7 @@ impl<S: BuildProvider> ClientBuilder<S> {
             timeout: Duration::from_secs(30),
             max_retries: 3,
             default_max_steps: 0,
-            user_agent: format!("aquaregia-ai-sdk/{}", env!("CARGO_PKG_VERSION")),
+            user_agent: format!("aquaregia/{}", env!("CARGO_PKG_VERSION")),
             settings,
         }
     }
@@ -182,7 +182,7 @@ impl<S: BuildProvider> ClientBuilder<S> {
         self
     }
 
-    /// Overrides the default SDK `User-Agent` header value.
+    /// Overrides the default Aquaregia `User-Agent` header value.
     pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
         self.user_agent = ua.into();
         self

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Stable error categories exposed by the SDK.
+/// Stable error categories exposed by Aquaregia.
 ///
 /// This enum provides a unified classification of errors that can occur
 /// during LLM operations, normalizing provider-specific error conditions
@@ -121,7 +121,7 @@ pub enum ErrorCode {
     UnsupportedOperation,
 }
 
-/// Rich error payload returned by all fallible SDK operations.
+/// Rich error payload returned by all fallible Aquaregia operations.
 ///
 /// This struct provides detailed error information including:
 /// - Stable error category ([`ErrorCode`])
@@ -225,10 +225,10 @@ impl Error {
     }
 }
 
-/// Maps HTTP status codes to stable SDK [`ErrorCode`] values.
+/// Maps HTTP status codes to stable Aquaregia [`ErrorCode`] values.
 ///
 /// This function provides a consistent mapping from HTTP status codes
-/// to SDK error categories, normalizing provider-specific HTTP responses.
+/// to Aquaregia error categories, normalizing provider-specific HTTP responses.
 ///
 /// # Arguments
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Aquaregia
 //!
-//! A lightweight agent SDK for Rust: build tool-using LLM agents that run on any provider.
+//! A lightweight Rust library for building tool-using LLM agents.
 //!
 //! ## Features
 //!

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -121,7 +121,7 @@ macro_rules! runtime_setters {
             self
         }
 
-        /// Overrides the default SDK `User-Agent` header value.
+        /// Overrides the default Aquaregia `User-Agent` header value.
         pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
             self.runtime.user_agent = Some(user_agent.into());
             self

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Shared request/response types and streaming events for Aquaregia.
 //!
-//! This module defines the core data structures used throughout the Aquaregia SDK:
+//! This module defines the core data structures used throughout Aquaregia:
 //!
 //! - **Messages**: Provider-agnostic chat message types with support for text, images, reasoning, and tool content
 //! - **Requests/Responses**: Structured generation request and response types


### PR DESCRIPTION
## Summary
- Reposition Aquaregia as a lightweight Rust library instead of an SDK
- Update README, crate metadata, docs pages, and public-facing wording
- Rename the default User-Agent from aquaregia-ai-sdk to aquaregia

## Verification
- cargo fmt --check
- cargo test
- pnpm --dir docs types:check