### PR TITLE
Simplify product positioning tagline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aquaregia"
 version = "0.3.3"
 edition = "2024"
-description = "A lightweight Rust library for building tool-using LLM agents."
+description = "A lightweight Rust library for building LLM agents."
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/minorcell/aquaregia"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Aquaregia
 
-**A lightweight Rust library for building tool-using LLM agents.**
+**A lightweight Rust library for building LLM agents.**
 
 [![Crates.io](https://img.shields.io/crates/v/aquaregia.svg)](https://crates.io/crates/aquaregia)
 [![Docs.rs](https://docs.rs/aquaregia/badge.svg)](https://docs.rs/aquaregia)

--- a/docs/content/docs/embeddings.mdx
+++ b/docs/content/docs/embeddings.mdx
@@ -18,7 +18,7 @@ let client = openai::Client::from_env()?;
 let response = client
     .embed(EmbedRequest::new(
         "text-embedding-3-small",
-        vec!["Aquaregia builds tool-using Rust agents."],
+        vec!["Aquaregia builds Rust agents."],
     ))
     .await?;
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: Build provider-backed LLM agents in Rust.
 ---
 
-Aquaregia is a lightweight Rust library for building tool-using LLM agents.
+Aquaregia is a lightweight Rust library for building LLM agents.
 
 The common shape is:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Aquaregia
 //!
-//! A lightweight Rust library for building tool-using LLM agents.
+//! A lightweight Rust library for building LLM agents.
 //!
 //! ## Features
 //!


### PR DESCRIPTION
## Summary
- Remove `tool-using` from the primary Aquaregia positioning tagline
- Update README, crate metadata, crate docs, and docs overview sample wording

## Verification
- cargo fmt --check
- pnpm --dir docs types:check