### PR TITLE
Add MCP client, remote agent example, and provider features

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.scratch
+target
+examples/*/target
+examples/*/Cargo.lock
+examples/remote_agent/remote_agent.sqlite*
+docs/.next
+docs/node_modules
+docs/out
+reference
+references

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "aquaregia"
 version = "0.3.3"
 dependencies = [
@@ -21,7 +30,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "reqwest",
+ "reqwest 0.12.28",
+ "rmcp",
  "schemars",
  "serde",
  "serde_json",
@@ -81,6 +91,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +143,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +200,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -441,6 +485,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +693,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +766,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -843,9 +946,43 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -860,6 +997,29 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "http",
+ "pin-project-lite",
+ "process-wrap",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1012,6 +1172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1201,19 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1131,6 +1314,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -1154,6 +1338,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1222,7 +1417,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1363,6 +1570,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,10 +1612,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1455,6 +1770,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ exclude = [
 name = "aquaregia"
 path = "src/lib.rs"
 
+[features]
+# MCP (Model Context Protocol) client support. Off by default; pulls in `rmcp`.
+mcp = ["dep:rmcp"]
+
 [dependencies]
 
 async-stream = "0.3"
@@ -45,6 +49,11 @@ serde_json = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.44", features = ["macros", "rt-multi-thread", "time"] }
 tokio-util = { version = "0.7" }
+rmcp = { version = "2", default-features = false, features = [
+    "client",
+    "transport-child-process",
+    "transport-streamable-http-client-reqwest",
+], optional = true }
 
 [dev-dependencies]
 http = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,11 @@ name = "aquaregia"
 path = "src/lib.rs"
 
 [features]
+default = ["openai", "anthropic", "google", "openai-compatible"]
+openai = []
+anthropic = []
+google = []
+openai-compatible = []
 # MCP (Model Context Protocol) client support. Off by default; pulls in `rmcp`.
 mcp = ["dep:rmcp"]
 

--- a/examples/remote_agent/.gitignore
+++ b/examples/remote_agent/.gitignore
@@ -1,0 +1,1 @@
+remote_agent.sqlite*

--- a/examples/remote_agent/Cargo.toml
+++ b/examples/remote_agent/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "aquaregia-example-remote-agent"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+aquaregia = { path = "../.." }
+async-stream = "0.3"
+axum = "0.8"
+futures-util = "0.3"
+rmcp = { version = "2.1.0", default-features = false, features = [
+    "server",
+    "client",
+    "macros",
+    "transport-streamable-http-server",
+    "transport-streamable-http-client-reqwest",
+] }
+schemars = { version = "0.8", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.44", features = ["macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = "0.7"
+uuid = { version = "1.11", features = ["v4"] }

--- a/examples/remote_agent/README.md
+++ b/examples/remote_agent/README.md
@@ -25,7 +25,7 @@ docker run -e SANDBOX_MCP_TOKEN=dev-token -p 8931:8931 remote-agent-sandbox
 ```bash
 SANDBOX_MCP_URL=http://127.0.0.1:8931/mcp \
 SANDBOX_MCP_TOKEN=dev-token \
-cargo run --manifest-path examples/remote_agent/Cargo.toml
+cargo run --manifest-path examples/remote_agent/Cargo.toml --bin aquaregia-example-remote-agent
 ```
 
 默认 Gateway 地址是 `http://127.0.0.1:3000`，打开后即可使用 Web App。

--- a/examples/remote_agent/README.md
+++ b/examples/remote_agent/README.md
@@ -1,0 +1,53 @@
+# Remote Agent Example
+
+## 是什么
+
+这是一个 Aquaregia 远程 agent 服务示例。
+
+它启动一个 HTTP Gateway，把 Aquaregia agent 通过 REST + SSE 暴露给客户端；
+agent 的工具调用会通过 MCP 转发到 Docker 沙箱中执行。Gateway 内置一个简单 Web App，
+可以创建 session、发起 run、查看实时事件和当前进程内的 run 回放。
+
+数据保存在进程内内存中，不使用数据库。Gateway 重启后，session、transcript、run history
+和 replay events 都会清空。
+
+## 如何使用
+
+先启动沙箱 MCP server：
+
+```bash
+docker build -f examples/remote_agent/sandbox/Dockerfile -t remote-agent-sandbox .
+docker run -e SANDBOX_MCP_TOKEN=dev-token -p 8931:8931 remote-agent-sandbox
+```
+
+再启动 Gateway。Gateway 会直接从当前环境变量读取 `DEEPSEEK_API_KEY`：
+
+```bash
+SANDBOX_MCP_URL=http://127.0.0.1:8931/mcp \
+SANDBOX_MCP_TOKEN=dev-token \
+cargo run --manifest-path examples/remote_agent/Cargo.toml
+```
+
+默认 Gateway 地址是 `http://127.0.0.1:3000`，打开后即可使用 Web App。
+
+也可以直接用 curl：
+
+```bash
+SESSION_ID=$(curl -sS -X POST http://127.0.0.1:3000/v1/sessions \
+  -H 'content-type: application/json' \
+  -d '{}' | jq -r '.session_id')
+
+curl -N -X POST "http://127.0.0.1:3000/v1/sessions/${SESSION_ID}/runs" \
+  -H 'content-type: application/json' \
+  -H 'accept: text/event-stream' \
+  -d '{"input":"在沙箱里运行 pwd 和 ls -la","stream":true}'
+```
+
+常用环境变量：
+
+- `DEEPSEEK_API_KEY`：DeepSeek API key，必填。
+- `REMOTE_AGENT_ADDR`：Gateway 监听地址，默认 `127.0.0.1:3000`。
+- `DEEPSEEK_MODEL`：模型名，默认 `deepseek-v4-pro`。
+- `DEEPSEEK_BASE_URL`：OpenAI-compatible base URL，默认 `https://api.deepseek.com`。
+- `SANDBOX_MCP_URL`：沙箱 MCP endpoint，默认 `http://127.0.0.1:8931/mcp`。
+- `SANDBOX_MCP_TOKEN`：Gateway 和 sandbox 共享的 Bearer token，默认 `dev-token`。

--- a/examples/remote_agent/design.md
+++ b/examples/remote_agent/design.md
@@ -1,0 +1,339 @@
+# Remote Agent 设计文档
+
+## 1. 概要
+
+这个 example 将 Aquaregia 组装成一个小型远程 agent 服务。客户端访问 HTTP
+Gateway，Gateway 为进程内 session 运行 Aquaregia agent loop，所有工具调用都通过
+MCP 转发到 Docker 沙箱执行。
+
+设计目标是在不修改根 `aquaregia` crate 的前提下完成集成。远程 MCP 工具通过
+`raw_schema` 和 `execute_raw` 适配成现有的 Aquaregia 工具。
+
+## 2. 目标
+
+- 展示服务形态的 agent example，而不是单个 API 调用。
+- 通过 SSE 保留完整的 `AgentStreamEvent` 生命周期。
+- 用进程内状态保存 session transcript、run 状态、事件回放数据和工具遥测。
+- 在容器边界内执行工具，避免工具直接运行在宿主机上。
+- 将 app-only 依赖全部限制在 `examples/remote_agent` 内。
+
+## 3. 非目标
+
+- 生产级认证、授权、计费或租户隔离。
+- OpenAI 兼容的 chat completions endpoint。
+- 在根 Aquaregia SDK 中内置 MCP 支持。
+- 超出 Docker 容器边界的高级沙箱加固。
+- 上下文压缩、transcript 裁剪或长期记忆。
+
+## 4. 架构
+
+```text
+client
+  |
+  | REST + SSE
+  v
+HTTP Gateway
+  |
+  | create session / start run / stream events
+  v
+Session Manager + Aquaregia Agent loop
+  |
+  | rmcp tools/list + tools/call
+  v
+Docker sandbox
+  |
+  | sandbox-mcp process executes tools inside the container
+  v
+bash / git / node / file system
+```
+
+### 组件职责
+
+| 组件 | 职责 |
+| --- | --- |
+| Gateway | HTTP 路由、请求校验、SSE 响应、健康检查 |
+| Web App | 管理 session/run、提交任务、查看 live events、回放事件和工具 schema |
+| Session Manager | session 生命周期、run 并发控制、transcript 交给 Aquaregia |
+| MCP Bridge | 将远程 MCP 工具转换成 `aquaregia::Tool` |
+| Telemetry Recorder | 将 stream event、usage 和工具调用耗时写入进程内状态 |
+| Sandbox MCP Server | 通过 Streamable HTTP 暴露容器内工具 |
+| In-memory Store | 保存 session、message、run 和 event，进程重启后清空 |
+
+## 5. 运行流程
+
+1. 客户端创建或选择一个 session。
+2. 客户端向 `POST /v1/sessions/{sid}/runs` 提交一次用户输入。
+3. Gateway 从内存 store 加载该 session 的 transcript，并追加新的 user message。
+4. Session Manager 使用 `agent.stream_messages(...)` 启动一次 Aquaregia loop。
+5. 单个 stream consumer 消费 `AgentStream`。
+6. consumer 将每个事件广播给 live SSE subscriber。
+7. consumer 同时把每个事件记录到内存 store，用于当前进程内回放。
+8. 工具调用进入 `ToolExecutor::execute`，穿过 MCP bridge，在沙箱容器内执行。
+9. loop 完成后，最终 `AgentOutput.transcript` 和 run summary 写回内存 store。
+10. Gateway 发送 `run_done` 并关闭 SSE 响应。
+
+## 6. HTTP API
+
+| Method | Path | 用途 |
+| --- | --- | --- |
+| `POST` | `/v1/sessions` | 创建 session |
+| `GET` | `/v1/sessions` | 列出 session |
+| `GET` | `/v1/sessions/{sid}` | 获取 session 元数据和 usage |
+| `DELETE` | `/v1/sessions/{sid}` | 归档 session |
+| `GET` | `/v1/sessions/{sid}/messages` | 读取 transcript |
+| `GET` | `/v1/sessions/{sid}/runs` | 列出 run history |
+| `POST` | `/v1/sessions/{sid}/runs` | 启动一次 agent loop |
+| `GET` | `/v1/sessions/{sid}/runs/{rid}` | 读取 run 状态或最终输出 |
+| `GET` | `/v1/sessions/{sid}/runs/{rid}/events` | 回放当前进程内 run events |
+| `GET` | `/v1/tools` | 列出桥接后的 MCP 工具 |
+| `GET` | `/healthz` | 检查 Gateway 和沙箱连通性 |
+
+### 创建 Session
+
+```json
+{
+  "model": "deepseek/deepseek-v4-pro",
+  "instructions": "You are a careful coding agent.",
+  "metadata": {}
+}
+```
+
+`model`、`instructions` 和 `metadata` 都是可选字段。未传时使用 example 默认值。
+
+### 启动 Run
+
+```json
+{
+  "input": "Clone this repository and count Rust source lines.",
+  "stream": true
+}
+```
+
+`stream: true` 返回 `text/event-stream`。第一帧是 `run_accepted`，包含
+`run_id` 和 `session_id`，便于前端在流结束后读取 run status 和 replay events。
+`stream: false` 阻塞到 run 完成，并返回最终 run object。
+
+## 7. SSE 事件
+
+SSE `event:` 名称直接映射 Aquaregia stream event。
+
+| SSE event | 来源 | 必要数据 |
+| --- | --- | --- |
+| `run_accepted` | Gateway | run id、session id |
+| `run_start` | `AgentStreamEvent::Start` | model、tool count、max steps |
+| `step_start` | `AgentStreamEvent::StepStart` | step index |
+| `model_delta` | `AgentStreamEvent::Model` | streamed model delta |
+| `tool_call_start` | `AgentStreamEvent::ToolCallStart` | call id、tool name、arguments |
+| `tool_call_finish` | `AgentStreamEvent::ToolCallFinish` | result、error flag、duration |
+| `step_finish` | `AgentStreamEvent::StepFinish` | finish reason、usage、step result |
+| `run_done` | `AgentStreamEvent::Done` | final output 和 usage total |
+| `error` | stream error | code 和 message |
+
+除 `run_accepted` 这类 transport-level 事件外，Gateway 不引入平行的 agent 事件
+DTO。Gateway 直接保存并流式返回序列化后的 agent event payload，只根据事件变体
+派生 SSE event 名称。
+
+## 8. Session 与 Run 规则
+
+- 一个 session 拥有一份累积 transcript。
+- 一个 run 表示针对一次新用户输入执行一次 agent loop。
+- 内存 store 是进程内事实源，进程重启后 session 和 run history 会丢失。
+- Session Manager 可以维护 active run handle 的内存注册表。
+- MVP 中，同一个 session 同时只允许一个 active run。
+- 当同一 session 已有 active run 时，新的 run 请求返回 conflict。
+- 多个不同 session 可以并发运行。
+- live SSE 使用 `tokio::sync::broadcast`。
+- 断线客户端可以在同一 Gateway 进程内回放 run events。
+
+## 9. MCP Bridge
+
+Gateway 启动时执行：
+
+1. 使用 `SANDBOX_MCP_URL` 构造 rmcp Streamable HTTP client。
+2. 使用 `SANDBOX_MCP_TOKEN` 配置 Bearer token。
+3. 调用 `list_all_tools()`。
+4. 将每个远程 MCP 工具转换成一个 `aquaregia::Tool`。
+5. 在每个 `AgentBuilder` 上注册转换后的工具列表。
+
+桥接契约：
+
+| MCP 字段或行为 | Aquaregia 映射 |
+| --- | --- |
+| tool name | `tool(name)` |
+| description | `.description(...)` |
+| `inputSchema` | `.raw_schema(...)` |
+| `tools/call` | `.execute_raw(...)` |
+| `structuredContent` | 返回的 `serde_json::Value` |
+| 第一个 text content block | fallback `{ "text": ... }` |
+| rmcp service error | `ToolExecError::Execution(...)` |
+
+实现骨架：
+
+```rust
+async fn bridge_all(peer: Arc<Peer<RoleClient>>) -> Result<Vec<aquaregia::Tool>, ToolExecError> {
+    let remote_tools = peer
+        .list_all_tools()
+        .await
+        .map_err(|err| ToolExecError::Execution(err.to_string()))?;
+
+    remote_tools
+        .into_iter()
+        .map(|remote_tool| bridge_one(peer.clone(), remote_tool))
+        .collect()
+}
+```
+
+`CallToolRequestParams` 要求 arguments 是 JSON object。MVP 中，非 object arguments
+按无参数处理，因为 Aquaregia 已经通过工具 schema 要求模型生成合法参数。
+
+## 10. 遥测
+
+`on_step_finish`、`on_tool_call_finish` 等 builder hook 是同步回调。streaming path
+不能在这些 hook 中直接做慢 I/O。
+
+流式 run 的处理规则：
+
+- 只消费一次 `AgentStream`。
+- 将每个事件广播给 live SSE subscriber。
+- 将每个事件同步记录到内存 store。
+
+非流式 run 的处理规则：
+
+- 复用同一条 streaming pipeline。
+- HTTP handler 等待 loop 完成后返回最终 run object。
+
+遥测来源：
+
+| 数据 | 来源 |
+| --- | --- |
+| 工具耗时 | `AgentToolCallFinish.duration_ms` |
+| 单 step token usage | `AgentStep.usage` |
+| 累计 token usage | `AgentOutput.usage_total` |
+| transcript | `AgentOutput.transcript` |
+| 工具参数和结果 | step tool calls 与 tool results |
+
+## 11. 沙箱
+
+沙箱是一个 Docker image，包含：
+
+- `sandbox-mcp`，使用 rmcp server API 编写的 Rust binary。
+- Node.js，用于 JavaScript 执行实验。
+- Git，用于仓库操作。
+- 作用域限制在容器内的可写工作目录。
+
+当前工具：
+
+| 工具 | 用途 |
+| --- | --- |
+| `bash` | 在容器工作目录中执行 shell 命令 |
+| `read_file` | 读取容器内文件 |
+| `write_file` | 写入容器内文件 |
+| `git` | 执行常见 git 操作 |
+| `node_eval` | 执行 Node.js 片段 |
+
+这些工具都只在容器工作目录内执行。路径型工具拒绝绝对路径和 `..`。
+
+## 12. 沙箱认证
+
+Gateway 和沙箱共享 `SANDBOX_MCP_TOKEN`。
+
+客户端行为：
+
+- 使用 sandbox URL 配置 rmcp Streamable HTTP client。
+- 通过 client transport 的 auth-header 支持传入 token。
+
+服务端行为：
+
+- rmcp 不提供适合本 example 的简单 Bearer token 校验。
+- 在 axum 或 tower middleware 中包裹 `StreamableHttpService`。
+- 当 `Authorization` header 不是 `Bearer <token>` 时拒绝请求。
+- 为容器网络配置 allowed hosts；rmcp 默认 host allowlist 偏向 loopback 场景。
+
+这是 example 级认证，不是生产身份体系。
+
+## 13. 存储模型
+
+```text
+StoreState
+  sessions: session_id -> SessionRecord
+  messages: session_id -> Vec<Message>
+  runs: run_id -> RunRecord
+  run_events: run_id -> Vec<StoredEvent>
+```
+
+这是有意的 0 数据库设计。`run_events` 用于当前进程内的回放和调试；
+重启 Gateway 后，session、transcript、run history 和 replay events 都会清空。
+
+## 14. Package Layout
+
+```text
+examples/remote_agent/
+  Cargo.toml
+  README.md
+  design.md
+  index.html
+  src/
+    main.rs
+    api.rs
+    session.rs
+    mcp_bridge.rs
+    telemetry.rs
+    store.rs
+    bin/
+      sandbox_mcp.rs
+  sandbox/
+    Dockerfile
+  static/
+    app.js
+    style.css
+```
+
+example package 通过下面的方式依赖本地 SDK：
+
+```toml
+aquaregia = { path = "../.." }
+```
+
+`axum`、`rmcp` 和 Docker 相关文件只放在 `examples/remote_agent` 内。
+
+## 15. 配置
+
+| 变量 | 使用方 | 用途 |
+| --- | --- | --- |
+| `DEEPSEEK_API_KEY` | Gateway | provider API key |
+| `DEEPSEEK_MODEL` | Gateway | 可选 model override |
+| `DEEPSEEK_BASE_URL` | Gateway | 可选 OpenAI-compatible base URL |
+| `SANDBOX_MCP_URL` | Gateway | Streamable HTTP MCP endpoint |
+| `SANDBOX_MCP_TOKEN` | Gateway 和 sandbox | 共享 Bearer token |
+
+## 16. 落地切片
+
+### Slice 1: 端到端 loop
+
+- 新增独立 Cargo package。
+- 新增只包含 `bash` 工具的 sandbox MCP server。
+- 新增 Gateway session 创建和 streamed run 执行。
+- 在内存中保留 session transcript。
+- 通过 Docker、Gateway 启动和一次 curl streamed run 验证。
+
+### Slice 2: 遥测与回放
+
+- 在内存中保留 `run_events`。
+- 新增 run status 和 event replay endpoints。
+- 验证 streamed output、replayed output 和工具 duration record 一致。
+
+### Slice 3: 完整 example 表面
+
+- 新增 `read_file`、`write_file`、`git` 和 `node_eval`。
+- 新增 `/v1/tools`。
+- 新增包含沙箱连通性检查的 `/healthz`。
+- 允许不同 session 并发，同时保持同一 session 只有一个 active run。
+- 用两个 session 和每个 session 至少一次工具调用 run 做验证。
+
+当前实现已覆盖三个切片的主要表面；后续改动应继续保持每个切片可独立验证。
+
+## 17. 待实现时确认
+
+- 确认所用 rmcp 版本中 `Tool.input_schema` 的准确 clone 写法。
+- 确认共享 rmcp client connection 是否应跨 run 复用，或在沙箱连接失败后重建。
+- 确认 stateful Streamable HTTP 行为不会和本 example 自己的 session ID 冲突。

--- a/examples/remote_agent/index.html
+++ b/examples/remote_agent/index.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Aquaregia Remote Agent</title>
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="topbar">
+        <div class="window-controls" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <div>
+            <h1>Remote Agent</h1>
+            <p>Aquaregia Gateway</p>
+          </div>
+        </div>
+        <div class="topbar-actions">
+          <div class="status-line" id="healthStatus">
+            <span class="status-dot status-muted"></span>
+            <span>healthz</span>
+          </div>
+          <button class="icon-button" id="refreshAllButton" type="button" aria-label="刷新">↻</button>
+        </div>
+      </header>
+
+      <main class="workspace">
+        <section class="thread" aria-label="Agent thread">
+          <div class="thread-head">
+            <div class="thread-title">
+              <h2 id="selectedSessionTitle">准备 session</h2>
+              <span id="selectedSessionMeta">正在连接 Gateway</span>
+            </div>
+            <div class="thread-actions">
+              <span class="run-state" id="activeRunLabel">idle</span>
+              <button class="button quiet small" id="newSessionButton" type="button">新会话</button>
+              <button class="button quiet small" id="refreshSessionButton" type="button">刷新</button>
+              <button class="button danger small" id="archiveSessionButton" type="button">归档</button>
+            </div>
+          </div>
+
+          <div class="thread-scroll" id="threadScroll">
+            <section class="message-stack" id="messagesList"></section>
+          </div>
+
+          <form class="composer" id="runForm">
+            <textarea id="runInput" rows="3" placeholder="向 remote agent 发送任务"></textarea>
+            <div class="composer-actions">
+              <label class="toggle">
+                <input id="streamToggle" type="checkbox" checked />
+                <span>stream</span>
+              </label>
+              <button class="send-button" id="startRunButton" type="submit" aria-label="启动 run">↑</button>
+            </div>
+          </form>
+        </section>
+      </main>
+    </div>
+
+    <script src="/static/app.js"></script>
+  </body>
+</html>

--- a/examples/remote_agent/sandbox/Dockerfile
+++ b/examples/remote_agent/sandbox/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1.92-bookworm AS builder
+
+WORKDIR /src
+COPY . .
+RUN cargo build --release --manifest-path examples/remote_agent/Cargo.toml --bin sandbox_mcp
+
+FROM node:22-bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY --from=builder /src/examples/remote_agent/target/release/sandbox_mcp /usr/local/bin/sandbox_mcp
+
+ENV SANDBOX_MCP_ADDR=0.0.0.0:8931
+ENV SANDBOX_WORKDIR=/workspace
+EXPOSE 8931
+
+CMD ["sandbox_mcp"]

--- a/examples/remote_agent/src/api.rs
+++ b/examples/remote_agent/src/api.rs
@@ -1,0 +1,325 @@
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use aquaregia::AgentStreamEvent;
+use axum::extract::{Path, State};
+use axum::http::{StatusCode, header};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use futures_util::Stream;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::session::{RunMode, SessionManager, SessionRunEvent};
+use crate::store::{RunRecord, SessionRecord, StoredEvent};
+
+#[derive(Clone)]
+pub struct AppState {
+    manager: Arc<SessionManager>,
+}
+
+impl AppState {
+    pub fn new(manager: SessionManager) -> Self {
+        Self {
+            manager: Arc::new(manager),
+        }
+    }
+}
+
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/", get(index))
+        .route("/favicon.ico", get(favicon))
+        .route("/static/app.js", get(app_js))
+        .route("/static/style.css", get(style_css))
+        .route("/healthz", get(healthz))
+        .route("/v1/tools", get(list_tools))
+        .route("/v1/sessions", post(create_session).get(list_sessions))
+        .route(
+            "/v1/sessions/{session_id}",
+            get(get_session).delete(delete_session),
+        )
+        .route("/v1/sessions/{session_id}/messages", get(list_messages))
+        .route(
+            "/v1/sessions/{session_id}/runs",
+            get(list_runs).post(start_run),
+        )
+        .route("/v1/sessions/{session_id}/runs/{run_id}", get(get_run))
+        .route(
+            "/v1/sessions/{session_id}/runs/{run_id}/events",
+            get(list_run_events),
+        )
+        .with_state(state)
+}
+
+async fn index() -> Html<&'static str> {
+    Html(include_str!("../index.html"))
+}
+
+async fn favicon() -> StatusCode {
+    StatusCode::NO_CONTENT
+}
+
+async fn app_js() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
+        include_str!("../static/app.js"),
+    )
+}
+
+async fn style_css() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "text/css; charset=utf-8")],
+        include_str!("../static/style.css"),
+    )
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateSessionRequest {
+    model: Option<String>,
+    instructions: Option<String>,
+    metadata: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateSessionResponse {
+    session_id: String,
+    session: SessionRecord,
+}
+
+#[derive(Debug, Deserialize)]
+struct StartRunRequest {
+    input: String,
+    #[serde(default = "default_stream")]
+    stream: bool,
+}
+
+fn default_stream() -> bool {
+    true
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    code: &'static str,
+    message: String,
+}
+
+async fn healthz(State(state): State<AppState>) -> Response {
+    match state.manager.health().await {
+        Ok(tools) => Json(json!({
+            "status": "ok",
+            "sandbox": "ok",
+            "tool_count": tools,
+        }))
+        .into_response(),
+        Err(err) => api_error(StatusCode::BAD_GATEWAY, "sandbox_unavailable", err),
+    }
+}
+
+async fn list_tools(State(state): State<AppState>) -> Response {
+    Json(state.manager.tools()).into_response()
+}
+
+async fn create_session(
+    State(state): State<AppState>,
+    Json(payload): Json<CreateSessionRequest>,
+) -> Response {
+    match state
+        .manager
+        .create_session(
+            payload.model,
+            payload.instructions,
+            payload.metadata.unwrap_or_else(|| json!({})),
+        )
+        .await
+    {
+        Ok(session) => Json(CreateSessionResponse {
+            session_id: session.id.clone(),
+            session,
+        })
+        .into_response(),
+        Err(err) => api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "create_session_failed",
+            err,
+        ),
+    }
+}
+
+async fn list_sessions(State(state): State<AppState>) -> Response {
+    match state.manager.list_sessions().await {
+        Ok(sessions) => Json(sessions).into_response(),
+        Err(err) => api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "list_sessions_failed",
+            err,
+        ),
+    }
+}
+
+async fn get_session(State(state): State<AppState>, Path(session_id): Path<String>) -> Response {
+    match state.manager.get_session(&session_id).await {
+        Ok(Some(session)) => Json(session).into_response(),
+        Ok(None) => api_error_text(StatusCode::NOT_FOUND, "not_found", "session not found"),
+        Err(err) => api_error(StatusCode::INTERNAL_SERVER_ERROR, "get_session_failed", err),
+    }
+}
+
+async fn delete_session(State(state): State<AppState>, Path(session_id): Path<String>) -> Response {
+    match state.manager.archive_session(&session_id).await {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => api_error_text(StatusCode::NOT_FOUND, "not_found", "session not found"),
+        Err(err) => api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "archive_session_failed",
+            err,
+        ),
+    }
+}
+
+async fn list_messages(State(state): State<AppState>, Path(session_id): Path<String>) -> Response {
+    match state.manager.list_messages(&session_id).await {
+        Ok(Some(messages)) => Json(messages).into_response(),
+        Ok(None) => api_error_text(StatusCode::NOT_FOUND, "not_found", "session not found"),
+        Err(err) => api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "list_messages_failed",
+            err,
+        ),
+    }
+}
+
+async fn list_runs(State(state): State<AppState>, Path(session_id): Path<String>) -> Response {
+    match state.manager.list_runs(&session_id).await {
+        Ok(Some(runs)) => Json(runs).into_response(),
+        Ok(None) => api_error_text(StatusCode::NOT_FOUND, "not_found", "session not found"),
+        Err(err) => api_error(StatusCode::INTERNAL_SERVER_ERROR, "list_runs_failed", err),
+    }
+}
+
+async fn start_run(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(payload): Json<StartRunRequest>,
+) -> Response {
+    if payload.input.trim().is_empty() {
+        return api_error_text(
+            StatusCode::BAD_REQUEST,
+            "invalid_input",
+            "input must not be empty",
+        );
+    }
+
+    let mode = if payload.stream {
+        RunMode::Stream
+    } else {
+        RunMode::Blocking
+    };
+
+    match state
+        .manager
+        .start_run(&session_id, payload.input, mode)
+        .await
+    {
+        Ok(crate::session::StartRunResult::Stream { stream }) => Sse::new(to_sse_stream(stream))
+            .keep_alive(KeepAlive::default())
+            .into_response(),
+        Ok(crate::session::StartRunResult::Blocking { run }) => Json(run).into_response(),
+        Err(crate::session::SessionError::NotFound) => {
+            api_error_text(StatusCode::NOT_FOUND, "not_found", "session not found")
+        }
+        Err(crate::session::SessionError::Conflict(message)) => {
+            api_error_text(StatusCode::CONFLICT, "run_conflict", &message)
+        }
+        Err(err) => api_error(StatusCode::INTERNAL_SERVER_ERROR, "start_run_failed", err),
+    }
+}
+
+async fn get_run(
+    State(state): State<AppState>,
+    Path((_session_id, run_id)): Path<(String, String)>,
+) -> Response {
+    match state.manager.get_run(&run_id).await {
+        Ok(Some(run)) => Json(run).into_response(),
+        Ok(None) => api_error_text(StatusCode::NOT_FOUND, "not_found", "run not found"),
+        Err(err) => api_error(StatusCode::INTERNAL_SERVER_ERROR, "get_run_failed", err),
+    }
+}
+
+async fn list_run_events(
+    State(state): State<AppState>,
+    Path((_session_id, run_id)): Path<(String, String)>,
+) -> Response {
+    match state.manager.list_run_events(&run_id).await {
+        Ok(events) => Json(events).into_response(),
+        Err(err) => api_error(StatusCode::INTERNAL_SERVER_ERROR, "list_events_failed", err),
+    }
+}
+
+fn to_sse_stream(
+    stream: impl Stream<Item = SessionRunEvent> + Send + 'static,
+) -> impl Stream<Item = Result<Event, Infallible>> {
+    async_stream::stream! {
+        futures_util::pin_mut!(stream);
+        while let Some(event) = futures_util::StreamExt::next(&mut stream).await {
+            yield Ok(to_sse_event(event));
+        }
+    }
+}
+
+fn to_sse_event(event: SessionRunEvent) -> Event {
+    match event {
+        SessionRunEvent::Accepted { run_id, session_id } => {
+            Event::default().event("run_accepted").data(
+                json!({
+                    "run_id": run_id,
+                    "session_id": session_id,
+                })
+                .to_string(),
+            )
+        }
+        SessionRunEvent::Agent(event) => Event::default()
+            .event(agent_event_name(&event))
+            .json_data(event)
+            .unwrap_or_else(|err| Event::default().event("error").data(err.to_string())),
+        SessionRunEvent::Error { code, message } => Event::default().event("error").data(
+            json!({
+                "code": code,
+                "message": message,
+            })
+            .to_string(),
+        ),
+    }
+}
+
+pub fn agent_event_name(event: &AgentStreamEvent) -> &'static str {
+    match event {
+        AgentStreamEvent::Start { .. } => "run_start",
+        AgentStreamEvent::StepStart { .. } => "step_start",
+        AgentStreamEvent::Model { .. } => "model_delta",
+        AgentStreamEvent::ToolCallStart { .. } => "tool_call_start",
+        AgentStreamEvent::ToolCallFinish { .. } => "tool_call_finish",
+        AgentStreamEvent::StepFinish { .. } => "step_finish",
+        AgentStreamEvent::Done { .. } => "run_done",
+    }
+}
+
+fn api_error(status: StatusCode, code: &'static str, err: impl std::fmt::Display) -> Response {
+    api_error_text(status, code, &err.to_string())
+}
+
+fn api_error_text(status: StatusCode, code: &'static str, message: &str) -> Response {
+    (
+        status,
+        Json(ErrorBody {
+            code,
+            message: message.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+#[allow(dead_code)]
+fn _assert_response_types(_: RunRecord, _: StoredEvent) {}

--- a/examples/remote_agent/src/bin/sandbox_mcp.rs
+++ b/examples/remote_agent/src/bin/sandbox_mcp.rs
@@ -1,0 +1,318 @@
+use std::net::SocketAddr;
+use std::path::{Component, Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Request, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::Response;
+use rmcp::{
+    ServerHandler,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{CallToolResult, ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router,
+    transport::streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    },
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::process::Command;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+
+const DEFAULT_ADDR: &str = "0.0.0.0:8931";
+const DEFAULT_WORKDIR: &str = "/workspace";
+const MAX_OUTPUT_BYTES: usize = 16 * 1024;
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr: SocketAddr = env_or("SANDBOX_MCP_ADDR", DEFAULT_ADDR).parse()?;
+    let token = Arc::new(env_or("SANDBOX_MCP_TOKEN", "dev-token"));
+    let workdir = PathBuf::from(env_or("SANDBOX_WORKDIR", DEFAULT_WORKDIR));
+    tokio::fs::create_dir_all(&workdir).await?;
+
+    let ct = CancellationToken::new();
+    let service = StreamableHttpService::new(
+        move || Ok(SandboxServer::new(workdir.clone())),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default()
+            .with_allowed_hosts(allowed_hosts(addr))
+            .with_cancellation_token(ct.child_token()),
+    );
+
+    let app =
+        axum::Router::new()
+            .nest_service("/mcp", service)
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&token),
+                check_bearer,
+            ));
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let shutdown = ct.clone();
+    tokio::spawn(async move {
+        let _ = tokio::signal::ctrl_c().await;
+        shutdown.cancel();
+    });
+
+    println!("remote_agent sandbox MCP listening on http://{addr}/mcp");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(ct.cancelled_owned())
+        .await?;
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct SandboxServer {
+    workdir: PathBuf,
+    tool_router: ToolRouter<Self>,
+}
+
+impl SandboxServer {
+    fn new(workdir: PathBuf) -> Self {
+        Self {
+            workdir,
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct BashArgs {
+    #[schemars(description = "Shell command to run inside the sandbox working directory.")]
+    cmd: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct FilePathArgs {
+    #[schemars(description = "Path relative to the sandbox working directory.")]
+    path: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct WriteFileArgs {
+    #[schemars(description = "Path relative to the sandbox working directory.")]
+    path: String,
+    #[schemars(description = "UTF-8 file contents to write.")]
+    content: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct GitArgs {
+    #[schemars(description = "Arguments passed after `git`, for example `status --short`.")]
+    args: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct NodeEvalArgs {
+    #[schemars(description = "JavaScript source to run with Node.js.")]
+    script: String,
+}
+
+#[tool_router]
+impl SandboxServer {
+    #[tool(description = "Run a shell command inside the sandbox working directory.")]
+    async fn bash(&self, Parameters(BashArgs { cmd }): Parameters<BashArgs>) -> CallToolResult {
+        command_result(run_shell(&self.workdir, &cmd).await)
+    }
+
+    #[tool(description = "Read a UTF-8 file from the sandbox working directory.")]
+    async fn read_file(
+        &self,
+        Parameters(FilePathArgs { path }): Parameters<FilePathArgs>,
+    ) -> CallToolResult {
+        match resolve_path(&self.workdir, &path) {
+            Ok(path) => match tokio::fs::read_to_string(&path).await {
+                Ok(content) => CallToolResult::structured(json!({
+                    "path": path,
+                    "content": content,
+                })),
+                Err(err) => structured_error("read_failed", err.to_string()),
+            },
+            Err(err) => structured_error("invalid_path", err),
+        }
+    }
+
+    #[tool(description = "Write a UTF-8 file inside the sandbox working directory.")]
+    async fn write_file(
+        &self,
+        Parameters(WriteFileArgs { path, content }): Parameters<WriteFileArgs>,
+    ) -> CallToolResult {
+        match resolve_path(&self.workdir, &path) {
+            Ok(path) => {
+                if let Some(parent) = path.parent()
+                    && let Err(err) = tokio::fs::create_dir_all(parent).await
+                {
+                    return structured_error("mkdir_failed", err.to_string());
+                }
+                match tokio::fs::write(&path, content).await {
+                    Ok(()) => CallToolResult::structured(json!({
+                        "path": path,
+                        "written": true,
+                    })),
+                    Err(err) => structured_error("write_failed", err.to_string()),
+                }
+            }
+            Err(err) => structured_error("invalid_path", err),
+        }
+    }
+
+    #[tool(description = "Run a git command inside the sandbox working directory.")]
+    async fn git(&self, Parameters(GitArgs { args }): Parameters<GitArgs>) -> CallToolResult {
+        command_result(run_shell(&self.workdir, &format!("git {args}")).await)
+    }
+
+    #[tool(description = "Run JavaScript with Node.js inside the sandbox working directory.")]
+    async fn node_eval(
+        &self,
+        Parameters(NodeEvalArgs { script }): Parameters<NodeEvalArgs>,
+    ) -> CallToolResult {
+        command_result(run_node(&self.workdir, &script).await)
+    }
+}
+
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for SandboxServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions("Tools execute inside the remote_agent Docker sandbox.")
+    }
+}
+
+async fn check_bearer(
+    State(token): State<Arc<String>>,
+    req: Request<Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let expected = format!("Bearer {}", token.as_str());
+    let authorized = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == expected);
+
+    if authorized {
+        Ok(next.run(req).await)
+    } else {
+        Err(StatusCode::UNAUTHORIZED)
+    }
+}
+
+async fn run_shell(workdir: &Path, command: &str) -> Result<Value, String> {
+    let child = Command::new("sh")
+        .arg("-lc")
+        .arg(command)
+        .current_dir(workdir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| err.to_string())?;
+
+    let output = timeout(COMMAND_TIMEOUT, child.wait_with_output())
+        .await
+        .map_err(|_| "command timed out".to_string())?
+        .map_err(|err| err.to_string())?;
+
+    Ok(json!({
+        "exit_code": output.status.code(),
+        "success": output.status.success(),
+        "stdout": truncate_output(&output.stdout),
+        "stderr": truncate_output(&output.stderr),
+    }))
+}
+
+async fn run_node(workdir: &Path, script: &str) -> Result<Value, String> {
+    let child = Command::new("node")
+        .arg("-e")
+        .arg(script)
+        .current_dir(workdir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| err.to_string())?;
+
+    let output = timeout(COMMAND_TIMEOUT, child.wait_with_output())
+        .await
+        .map_err(|_| "node execution timed out".to_string())?
+        .map_err(|err| err.to_string())?;
+
+    Ok(json!({
+        "exit_code": output.status.code(),
+        "success": output.status.success(),
+        "stdout": truncate_output(&output.stdout),
+        "stderr": truncate_output(&output.stderr),
+    }))
+}
+
+fn command_result(result: Result<Value, String>) -> CallToolResult {
+    match result {
+        Ok(value) if value.get("success").and_then(Value::as_bool) == Some(true) => {
+            CallToolResult::structured(value)
+        }
+        Ok(value) => CallToolResult::structured_error(value),
+        Err(message) => structured_error("command_failed", message),
+    }
+}
+
+fn structured_error(code: &str, message: impl Into<String>) -> CallToolResult {
+    CallToolResult::structured_error(json!({
+        "code": code,
+        "message": message.into(),
+    }))
+}
+
+fn resolve_path(root: &Path, input: &str) -> Result<PathBuf, String> {
+    let path = Path::new(input);
+    if path.is_absolute() {
+        return Err("path must be relative to the sandbox working directory".to_string());
+    }
+
+    let mut resolved = root.to_path_buf();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => resolved.push(part),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                return Err("path must not contain `..`".to_string());
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err("path must be relative to the sandbox working directory".to_string());
+            }
+        }
+    }
+    Ok(resolved)
+}
+
+fn truncate_output(bytes: &[u8]) -> String {
+    let truncated = bytes.len() > MAX_OUTPUT_BYTES;
+    let end = bytes.len().min(MAX_OUTPUT_BYTES);
+    let mut text = String::from_utf8_lossy(&bytes[..end]).to_string();
+    if truncated {
+        text.push_str("\n[output truncated]");
+    }
+    text
+}
+
+fn allowed_hosts(addr: SocketAddr) -> Vec<String> {
+    let port = addr.port();
+    env_or(
+        "SANDBOX_ALLOWED_HOSTS",
+        &format!("127.0.0.1:{port},localhost:{port}"),
+    )
+    .split(',')
+    .map(str::trim)
+    .filter(|host| !host.is_empty())
+    .map(ToString::to_string)
+    .collect()
+}
+
+fn env_or(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}

--- a/examples/remote_agent/src/main.rs
+++ b/examples/remote_agent/src/main.rs
@@ -1,0 +1,92 @@
+mod api;
+mod mcp_bridge;
+mod session;
+mod store;
+mod telemetry;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::Router;
+use tokio_util::sync::CancellationToken;
+
+const DEFAULT_BASE_URL: &str = "https://api.deepseek.com";
+const DEFAULT_MODEL: &str = "deepseek-v4-pro";
+const DEFAULT_SANDBOX_URL: &str = "http://127.0.0.1:8931/mcp";
+const DEFAULT_GATEWAY_ADDR: &str = "127.0.0.1:3000";
+const DEFAULT_INSTRUCTIONS: &str = r#"
+You are a remote coding agent.
+
+Use the sandbox tools for repository, shell, Node.js, and file-system work.
+Keep commands scoped to the sandbox working directory. Explain what you did and
+include concise command results in your final answer.
+"#;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let config = AppConfig::from_env();
+    let store = store::Store::new();
+
+    let provider = aquaregia::providers::openai_compatible::Client::builder()
+        .base_url(config.provider_base_url.clone())
+        .api_key_from_env("DEEPSEEK_API_KEY")
+        .build()?;
+
+    let mcp = mcp_bridge::McpBridge::connect(&config.sandbox_url, &config.sandbox_token).await?;
+    let manager = session::SessionManager::new(
+        Arc::new(store),
+        Arc::new(provider),
+        mcp,
+        config.default_model.clone(),
+        DEFAULT_INSTRUCTIONS.trim().to_string(),
+    );
+
+    let app = api::router(api::AppState::new(manager));
+    serve(app, config.gateway_addr).await?;
+    Ok(())
+}
+
+async fn serve(
+    app: Router,
+    addr: SocketAddr,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let token = CancellationToken::new();
+    let shutdown_token = token.clone();
+    tokio::spawn(async move {
+        let _ = tokio::signal::ctrl_c().await;
+        shutdown_token.cancel();
+    });
+
+    println!("remote_agent gateway listening on http://{addr}");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(token.cancelled_owned())
+        .await?;
+    Ok(())
+}
+
+struct AppConfig {
+    gateway_addr: SocketAddr,
+    default_model: String,
+    provider_base_url: String,
+    sandbox_url: String,
+    sandbox_token: String,
+}
+
+impl AppConfig {
+    fn from_env() -> Self {
+        Self {
+            gateway_addr: env_or("REMOTE_AGENT_ADDR", DEFAULT_GATEWAY_ADDR)
+                .parse()
+                .expect("REMOTE_AGENT_ADDR must be a socket address"),
+            default_model: env_or("DEEPSEEK_MODEL", DEFAULT_MODEL),
+            provider_base_url: env_or("DEEPSEEK_BASE_URL", DEFAULT_BASE_URL),
+            sandbox_url: env_or("SANDBOX_MCP_URL", DEFAULT_SANDBOX_URL),
+            sandbox_token: env_or("SANDBOX_MCP_TOKEN", "dev-token"),
+        }
+    }
+}
+
+fn env_or(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}

--- a/examples/remote_agent/src/mcp_bridge.rs
+++ b/examples/remote_agent/src/mcp_bridge.rs
@@ -1,0 +1,136 @@
+use std::sync::Arc;
+
+use aquaregia::tool::ToolExecError;
+use aquaregia::{Tool, tool};
+use rmcp::model::{CallToolRequestParams, ClientInfo};
+use rmcp::service::{RoleClient, RunningService, ServiceExt};
+use rmcp::transport::{
+    StreamableHttpClientTransport, streamable_http_client::StreamableHttpClientTransportConfig,
+};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+type McpClient = RunningService<RoleClient, ClientInfo>;
+
+#[derive(Clone)]
+pub struct McpBridge {
+    client: Arc<McpClient>,
+    tools: Vec<Tool>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolInfo {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+impl McpBridge {
+    pub async fn connect(
+        url: &str,
+        token: &str,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let config = StreamableHttpClientTransportConfig::with_uri(url.to_string())
+            .auth_header(token.to_string());
+        let transport = StreamableHttpClientTransport::from_config(config);
+        let client = ClientInfo::default().serve(transport).await?;
+        let client = Arc::new(client);
+        let tools = bridge_all(Arc::clone(&client)).await?;
+        Ok(Self { client, tools })
+    }
+
+    pub fn tools(&self) -> Vec<Tool> {
+        self.tools.clone()
+    }
+
+    pub fn tool_info(&self) -> Vec<ToolInfo> {
+        self.tools
+            .iter()
+            .map(|tool| ToolInfo {
+                name: tool.descriptor.name.clone(),
+                description: tool.descriptor.description.clone(),
+                input_schema: tool.descriptor.input_schema.clone(),
+            })
+            .collect()
+    }
+
+    pub async fn health(&self) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(self.client.list_all_tools().await?.len())
+    }
+}
+
+async fn bridge_all(client: Arc<McpClient>) -> Result<Vec<Tool>, ToolExecError> {
+    let remote_tools = client
+        .list_all_tools()
+        .await
+        .map_err(|err| ToolExecError::Execution(err.to_string()))?;
+
+    Ok(remote_tools
+        .into_iter()
+        .map(|remote_tool| {
+            let name = remote_tool.name.to_string();
+            let call_name = name.clone();
+            let description = remote_tool
+                .description
+                .map(|description| description.to_string())
+                .unwrap_or_default();
+            let input_schema = Value::Object((*remote_tool.input_schema).clone());
+            let client = Arc::clone(&client);
+
+            tool(name)
+                .description(description)
+                .raw_schema(input_schema)
+                .execute_raw(move |args| {
+                    let client = Arc::clone(&client);
+                    let call_name = call_name.clone();
+                    async move { call_remote_tool(client, call_name, args).await }
+                })
+        })
+        .collect())
+}
+
+async fn call_remote_tool(
+    client: Arc<McpClient>,
+    name: String,
+    args: Value,
+) -> Result<Value, ToolExecError> {
+    let mut params = CallToolRequestParams::new(name);
+    if let Value::Object(arguments) = args {
+        params = params.with_arguments(arguments);
+    }
+
+    let result = client
+        .call_tool(params)
+        .await
+        .map_err(|err| ToolExecError::Execution(err.to_string()))?;
+    let output = result_output_value(&result);
+
+    if result.is_error == Some(true) {
+        return Err(ToolExecError::Execution(error_message(output)));
+    }
+
+    Ok(output)
+}
+
+fn result_output_value(result: &rmcp::model::CallToolResult) -> Value {
+    if let Some(value) = &result.structured_content {
+        return value.clone();
+    }
+
+    let text = result
+        .content
+        .first()
+        .and_then(|content| content.as_text())
+        .map(|text| text.text.clone())
+        .unwrap_or_default();
+    json!({ "text": text })
+}
+
+fn error_message(value: Value) -> String {
+    value
+        .get("message")
+        .and_then(Value::as_str)
+        .or_else(|| value.get("error").and_then(Value::as_str))
+        .map(ToString::to_string)
+        .unwrap_or_else(|| value.to_string())
+}

--- a/examples/remote_agent/src/session.rs
+++ b/examples/remote_agent/src/session.rs
@@ -1,0 +1,391 @@
+use std::collections::HashSet;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use aquaregia::{Agent, AgentOutput, AgentStreamEvent, Message};
+use futures_util::{Stream, StreamExt};
+use serde_json::Value;
+use tokio::sync::{Mutex, broadcast};
+use uuid::Uuid;
+
+use crate::mcp_bridge::{McpBridge, ToolInfo};
+use crate::store::{RunRecord, SessionRecord, Store, StoreError, StoredEvent};
+use crate::telemetry;
+
+#[derive(Clone)]
+pub struct SessionManager {
+    store: Arc<Store>,
+    provider: Arc<aquaregia::providers::openai_compatible::Client>,
+    mcp: McpBridge,
+    default_model: String,
+    default_instructions: String,
+    active_runs: Arc<Mutex<HashSet<String>>>,
+}
+
+pub enum RunMode {
+    Stream,
+    Blocking,
+}
+
+pub enum StartRunResult {
+    Stream {
+        stream: Pin<Box<dyn Stream<Item = SessionRunEvent> + Send>>,
+    },
+    Blocking {
+        run: RunRecord,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum SessionRunEvent {
+    Accepted { run_id: String, session_id: String },
+    Agent(AgentStreamEvent),
+    Error { code: String, message: String },
+}
+
+#[derive(Debug)]
+pub enum SessionError {
+    NotFound,
+    Conflict(String),
+    Internal(String),
+}
+
+impl std::fmt::Display for SessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionError::NotFound => write!(f, "not found"),
+            SessionError::Conflict(message) => write!(f, "{message}"),
+            SessionError::Internal(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for SessionError {}
+
+impl From<StoreError> for SessionError {
+    fn from(err: StoreError) -> Self {
+        SessionError::Internal(err.to_string())
+    }
+}
+
+impl From<aquaregia::Error> for SessionError {
+    fn from(err: aquaregia::Error) -> Self {
+        SessionError::Internal(err.to_string())
+    }
+}
+
+impl SessionManager {
+    pub fn new(
+        store: Arc<Store>,
+        provider: Arc<aquaregia::providers::openai_compatible::Client>,
+        mcp: McpBridge,
+        default_model: String,
+        default_instructions: String,
+    ) -> Self {
+        Self {
+            store,
+            provider,
+            mcp,
+            default_model,
+            default_instructions,
+            active_runs: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    pub async fn create_session(
+        &self,
+        model: Option<String>,
+        instructions: Option<String>,
+        metadata: Value,
+    ) -> Result<SessionRecord, SessionError> {
+        let id = format!("sess_{}", short_id());
+        let model = model.unwrap_or_else(|| self.default_model.clone());
+        let instructions = instructions.unwrap_or_else(|| self.default_instructions.clone());
+        Ok(self
+            .store
+            .create_session(&id, &model, &instructions, &metadata)
+            .await?)
+    }
+
+    pub async fn list_sessions(&self) -> Result<Vec<SessionRecord>, SessionError> {
+        Ok(self.store.list_sessions().await?)
+    }
+
+    pub async fn get_session(&self, id: &str) -> Result<Option<SessionRecord>, SessionError> {
+        Ok(self.store.get_session(id).await?)
+    }
+
+    pub async fn archive_session(&self, id: &str) -> Result<bool, SessionError> {
+        Ok(self.store.archive_session(id).await?)
+    }
+
+    pub async fn list_messages(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<Vec<Message>>, SessionError> {
+        if self.store.get_session(session_id).await?.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(self.store.load_messages(session_id).await?))
+    }
+
+    pub async fn get_run(&self, run_id: &str) -> Result<Option<RunRecord>, SessionError> {
+        Ok(self.store.get_run(run_id).await?)
+    }
+
+    pub async fn list_runs(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<Vec<RunRecord>>, SessionError> {
+        if self.store.get_session(session_id).await?.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(self.store.list_runs(session_id).await?))
+    }
+
+    pub async fn list_run_events(&self, run_id: &str) -> Result<Vec<StoredEvent>, SessionError> {
+        Ok(self.store.list_events(run_id).await?)
+    }
+
+    pub fn tools(&self) -> Vec<ToolInfo> {
+        self.mcp.tool_info()
+    }
+
+    pub async fn health(&self) -> Result<usize, SessionError> {
+        self.mcp
+            .health()
+            .await
+            .map_err(|err| SessionError::Internal(err.to_string()))
+    }
+
+    pub async fn start_run(
+        &self,
+        session_id: &str,
+        input: String,
+        mode: RunMode,
+    ) -> Result<StartRunResult, SessionError> {
+        let session = self
+            .store
+            .get_session(session_id)
+            .await?
+            .ok_or(SessionError::NotFound)?;
+        self.claim_session(session_id).await?;
+
+        let result = match mode {
+            RunMode::Stream => self.start_streaming_run(session, input).await,
+            RunMode::Blocking => self.start_blocking_run(session, input).await,
+        };
+
+        if result.is_err() {
+            self.release_session(session_id).await;
+        }
+        result
+    }
+
+    async fn start_streaming_run(
+        &self,
+        session: SessionRecord,
+        input: String,
+    ) -> Result<StartRunResult, SessionError> {
+        let run_id = format!("run_{}", short_id());
+        self.store.create_run(&run_id, &session.id, &input).await?;
+        let mut messages = self.store.load_messages(&session.id).await?;
+        messages.push(Message::user_text(input));
+        let agent = Arc::new(self.build_agent(&session)?);
+
+        let (tx, rx) = broadcast::channel(256);
+        let session_id = session.id.clone();
+        let task = RunTask {
+            store: Arc::clone(&self.store),
+            active_runs: Arc::clone(&self.active_runs),
+            session_id: session_id.clone(),
+            run_id: run_id.clone(),
+            agent,
+            messages,
+            tx,
+        };
+        tokio::spawn(async move {
+            task.run().await;
+        });
+
+        Ok(StartRunResult::Stream {
+            stream: Box::pin(broadcast_stream(rx, run_id, session_id)),
+        })
+    }
+
+    async fn start_blocking_run(
+        &self,
+        session: SessionRecord,
+        input: String,
+    ) -> Result<StartRunResult, SessionError> {
+        let run_id = format!("run_{}", short_id());
+        self.store.create_run(&run_id, &session.id, &input).await?;
+        let mut messages = self.store.load_messages(&session.id).await?;
+        messages.push(Message::user_text(input));
+        let agent = self.build_agent(&session)?;
+
+        let result = run_to_completion(
+            Arc::clone(&self.store),
+            session.id.clone(),
+            run_id.clone(),
+            Arc::new(agent),
+            messages,
+            None,
+        )
+        .await;
+        self.release_session(&session.id).await;
+        result?;
+
+        let run = self.store.get_run(&run_id).await?.ok_or_else(|| {
+            SessionError::Internal("run disappeared after completion".to_string())
+        })?;
+        Ok(StartRunResult::Blocking { run })
+    }
+
+    fn build_agent(&self, session: &SessionRecord) -> Result<Agent, SessionError> {
+        Ok(self
+            .provider
+            .agent(session.model.clone())
+            .instructions(session.instructions.clone())
+            .tools(self.mcp.tools())
+            .max_steps(12)
+            .temperature(0.2)
+            .max_output_tokens(2_000)
+            .build()?)
+    }
+
+    async fn claim_session(&self, session_id: &str) -> Result<(), SessionError> {
+        let mut active = self.active_runs.lock().await;
+        if active.contains(session_id) {
+            return Err(SessionError::Conflict(format!(
+                "session {session_id} already has an active run"
+            )));
+        }
+        active.insert(session_id.to_string());
+        Ok(())
+    }
+
+    async fn release_session(&self, session_id: &str) {
+        self.active_runs.lock().await.remove(session_id);
+    }
+}
+
+struct RunTask {
+    store: Arc<Store>,
+    active_runs: Arc<Mutex<HashSet<String>>>,
+    session_id: String,
+    run_id: String,
+    agent: Arc<Agent>,
+    messages: Vec<Message>,
+    tx: broadcast::Sender<SessionRunEvent>,
+}
+
+impl RunTask {
+    async fn run(self) {
+        let result = run_to_completion(
+            Arc::clone(&self.store),
+            self.session_id.clone(),
+            self.run_id.clone(),
+            self.agent,
+            self.messages,
+            Some(self.tx.clone()),
+        )
+        .await;
+
+        if let Err(err) = result {
+            let message = err.to_string();
+            let _ = self.store.fail_run(&self.run_id, &message).await;
+            let _ = self.tx.send(SessionRunEvent::Error {
+                code: "run_failed".to_string(),
+                message,
+            });
+        }
+
+        self.active_runs.lock().await.remove(&self.session_id);
+    }
+}
+
+async fn run_to_completion(
+    store: Arc<Store>,
+    session_id: String,
+    run_id: String,
+    agent: Arc<Agent>,
+    messages: Vec<Message>,
+    tx: Option<broadcast::Sender<SessionRunEvent>>,
+) -> Result<(), SessionError> {
+    let mut final_output = None::<AgentOutput>;
+    let mut event_seq = 0_i64;
+    let mut stream = agent.stream_messages(messages).await?;
+
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(event) => {
+                if let AgentStreamEvent::Done { output } = &event {
+                    final_output = Some(output.clone());
+                }
+                if let Err(err) = telemetry::record(&store, &run_id, event_seq, &event).await {
+                    eprintln!("failed to store run event for {run_id}: {err}");
+                }
+                event_seq += 1;
+                if let Some(tx) = &tx {
+                    let _ = tx.send(SessionRunEvent::Agent(event));
+                }
+            }
+            Err(err) => {
+                return Err(SessionError::Internal(err.to_string()));
+            }
+        }
+    }
+
+    let output = final_output
+        .ok_or_else(|| SessionError::Internal("agent stream ended without run_done".to_string()))?;
+    store
+        .replace_messages(&session_id, &output.transcript)
+        .await?;
+    store
+        .finish_run(
+            &run_id,
+            output.steps,
+            &output.output_text,
+            &serde_json::to_value(&output.usage_total)
+                .map_err(|err| SessionError::Internal(err.to_string()))?,
+        )
+        .await?;
+    Ok(())
+}
+
+fn broadcast_stream(
+    mut rx: broadcast::Receiver<SessionRunEvent>,
+    run_id: String,
+    session_id: String,
+) -> impl Stream<Item = SessionRunEvent> + Send + 'static {
+    async_stream::stream! {
+        yield SessionRunEvent::Accepted { run_id, session_id };
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let done = matches!(
+                        event,
+                        SessionRunEvent::Agent(AgentStreamEvent::Done { .. })
+                            | SessionRunEvent::Error { .. }
+                    );
+                    yield event;
+                    if done {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    yield SessionRunEvent::Error {
+                        code: "event_lagged".to_string(),
+                        message: "SSE receiver lagged behind the run event stream".to_string(),
+                    };
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    }
+}
+
+fn short_id() -> String {
+    Uuid::new_v4().simple().to_string()
+}

--- a/examples/remote_agent/src/store.rs
+++ b/examples/remote_agent/src/store.rs
@@ -1,0 +1,267 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use aquaregia::Message;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+#[derive(Clone, Default)]
+pub struct Store {
+    state: Arc<Mutex<StoreState>>,
+}
+
+#[derive(Default)]
+struct StoreState {
+    sessions: HashMap<String, SessionRecord>,
+    messages: HashMap<String, Vec<Message>>,
+    runs: HashMap<String, RunRecord>,
+    run_events: HashMap<String, Vec<StoredEvent>>,
+}
+
+#[derive(Debug)]
+pub struct StoreError {
+    message: String,
+}
+
+impl StoreError {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for StoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+pub type StoreResult<T> = Result<T, StoreError>;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionRecord {
+    pub id: String,
+    pub model: String,
+    pub instructions: String,
+    pub status: String,
+    pub metadata: Value,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunRecord {
+    pub id: String,
+    pub session_id: String,
+    pub status: String,
+    pub input: String,
+    pub steps: i64,
+    pub output_text: Option<String>,
+    pub usage_total: Option<Value>,
+    pub started_at: i64,
+    pub finished_at: Option<i64>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StoredEvent {
+    pub seq: i64,
+    pub ts: i64,
+    pub event_type: String,
+    pub payload: Value,
+}
+
+impl Store {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn create_session(
+        &self,
+        id: &str,
+        model: &str,
+        instructions: &str,
+        metadata: &Value,
+    ) -> StoreResult<SessionRecord> {
+        let now = now_ms();
+        let record = SessionRecord {
+            id: id.to_string(),
+            model: model.to_string(),
+            instructions: instructions.to_string(),
+            status: "active".to_string(),
+            metadata: metadata.clone(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        let mut state = self.state.lock().await;
+        state.sessions.insert(id.to_string(), record.clone());
+        state.messages.entry(id.to_string()).or_default();
+        Ok(record)
+    }
+
+    pub async fn list_sessions(&self) -> StoreResult<Vec<SessionRecord>> {
+        let state = self.state.lock().await;
+        let mut sessions = state.sessions.values().cloned().collect::<Vec<_>>();
+        sessions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(sessions)
+    }
+
+    pub async fn get_session(&self, id: &str) -> StoreResult<Option<SessionRecord>> {
+        let state = self.state.lock().await;
+        Ok(state.sessions.get(id).cloned())
+    }
+
+    pub async fn archive_session(&self, id: &str) -> StoreResult<bool> {
+        let mut state = self.state.lock().await;
+        let Some(session) = state.sessions.get_mut(id) else {
+            return Ok(false);
+        };
+        if session.status == "archived" {
+            return Ok(false);
+        }
+        session.status = "archived".to_string();
+        session.updated_at = now_ms();
+        Ok(true)
+    }
+
+    pub async fn load_messages(&self, session_id: &str) -> StoreResult<Vec<Message>> {
+        let state = self.state.lock().await;
+        Ok(state.messages.get(session_id).cloned().unwrap_or_default())
+    }
+
+    pub async fn replace_messages(
+        &self,
+        session_id: &str,
+        messages: &[Message],
+    ) -> StoreResult<()> {
+        let mut state = self.state.lock().await;
+        let Some(session) = state.sessions.get_mut(session_id) else {
+            return Err(StoreError::new(format!("session {session_id} not found")));
+        };
+        session.updated_at = now_ms();
+        state
+            .messages
+            .insert(session_id.to_string(), messages.to_vec());
+        Ok(())
+    }
+
+    pub async fn create_run(
+        &self,
+        id: &str,
+        session_id: &str,
+        input: &str,
+    ) -> StoreResult<RunRecord> {
+        let mut state = self.state.lock().await;
+        if !state.sessions.contains_key(session_id) {
+            return Err(StoreError::new(format!("session {session_id} not found")));
+        }
+
+        let now = now_ms();
+        let record = RunRecord {
+            id: id.to_string(),
+            session_id: session_id.to_string(),
+            status: "running".to_string(),
+            input: input.to_string(),
+            steps: 0,
+            output_text: None,
+            usage_total: None,
+            started_at: now,
+            finished_at: None,
+            error: None,
+        };
+        state.runs.insert(id.to_string(), record.clone());
+        state.run_events.entry(id.to_string()).or_default();
+        Ok(record)
+    }
+
+    pub async fn get_run(&self, id: &str) -> StoreResult<Option<RunRecord>> {
+        let state = self.state.lock().await;
+        Ok(state.runs.get(id).cloned())
+    }
+
+    pub async fn list_runs(&self, session_id: &str) -> StoreResult<Vec<RunRecord>> {
+        let state = self.state.lock().await;
+        let mut runs = state
+            .runs
+            .values()
+            .filter(|run| run.session_id == session_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        runs.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        Ok(runs)
+    }
+
+    pub async fn finish_run(
+        &self,
+        id: &str,
+        steps: u32,
+        output_text: &str,
+        usage_total: &Value,
+    ) -> StoreResult<()> {
+        let mut state = self.state.lock().await;
+        let Some(run) = state.runs.get_mut(id) else {
+            return Err(StoreError::new(format!("run {id} not found")));
+        };
+        run.status = "completed".to_string();
+        run.steps = steps as i64;
+        run.output_text = Some(output_text.to_string());
+        run.usage_total = Some(usage_total.clone());
+        run.finished_at = Some(now_ms());
+        Ok(())
+    }
+
+    pub async fn fail_run(&self, id: &str, error: &str) -> StoreResult<()> {
+        let mut state = self.state.lock().await;
+        let Some(run) = state.runs.get_mut(id) else {
+            return Err(StoreError::new(format!("run {id} not found")));
+        };
+        run.status = "failed".to_string();
+        run.error = Some(error.to_string());
+        run.finished_at = Some(now_ms());
+        Ok(())
+    }
+
+    pub async fn insert_event(
+        &self,
+        run_id: &str,
+        seq: i64,
+        event_type: &str,
+        payload: &Value,
+    ) -> StoreResult<()> {
+        let mut state = self.state.lock().await;
+        if !state.runs.contains_key(run_id) {
+            return Err(StoreError::new(format!("run {run_id} not found")));
+        }
+        state
+            .run_events
+            .entry(run_id.to_string())
+            .or_default()
+            .push(StoredEvent {
+                seq,
+                ts: now_ms(),
+                event_type: event_type.to_string(),
+                payload: payload.clone(),
+            });
+        Ok(())
+    }
+
+    pub async fn list_events(&self, run_id: &str) -> StoreResult<Vec<StoredEvent>> {
+        let state = self.state.lock().await;
+        let mut events = state.run_events.get(run_id).cloned().unwrap_or_default();
+        events.sort_by(|a, b| a.seq.cmp(&b.seq));
+        Ok(events)
+    }
+}
+
+pub fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}

--- a/examples/remote_agent/src/telemetry.rs
+++ b/examples/remote_agent/src/telemetry.rs
@@ -1,0 +1,17 @@
+use aquaregia::AgentStreamEvent;
+
+use crate::api::agent_event_name;
+use crate::store::{Store, StoreResult};
+
+pub async fn record(
+    store: &Store,
+    run_id: &str,
+    seq: i64,
+    event: &AgentStreamEvent,
+) -> StoreResult<()> {
+    let payload = serde_json::to_value(event)
+        .map_err(|err| crate::store::StoreError::new(err.to_string()))?;
+    store
+        .insert_event(run_id, seq, agent_event_name(event), &payload)
+        .await
+}

--- a/examples/remote_agent/static/app.js
+++ b/examples/remote_agent/static/app.js
@@ -1,0 +1,666 @@
+const state = {
+  health: null,
+  sessions: [],
+  selectedSession: null,
+  runs: [],
+  selectedRun: null,
+  runEvents: new Map(),
+  liveEvents: [],
+  activeRunId: null,
+  pendingInput: "",
+  running: false,
+  error: "",
+};
+
+const els = {};
+
+document.addEventListener("DOMContentLoaded", () => {
+  bindElements();
+  bindEvents();
+  render();
+  refreshAll();
+});
+
+function bindElements() {
+  for (const id of [
+    "healthStatus",
+    "refreshAllButton",
+    "newSessionButton",
+    "selectedSessionTitle",
+    "selectedSessionMeta",
+    "refreshSessionButton",
+    "archiveSessionButton",
+    "runForm",
+    "runInput",
+    "streamToggle",
+    "startRunButton",
+    "messagesList",
+    "threadScroll",
+    "activeRunLabel",
+  ]) {
+    els[id] = document.getElementById(id);
+  }
+}
+
+function bindEvents() {
+  els.refreshAllButton.addEventListener("click", refreshAll);
+  els.newSessionButton.addEventListener("click", createDefaultSession);
+  els.refreshSessionButton.addEventListener("click", () => {
+    if (state.selectedSession) selectSession(state.selectedSession.id);
+  });
+  els.archiveSessionButton.addEventListener("click", archiveSelectedSession);
+  els.runForm.addEventListener("submit", startRun);
+  els.runInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
+      event.preventDefault();
+      els.runForm.requestSubmit();
+    }
+  });
+}
+
+async function refreshAll() {
+  state.error = "";
+  await Promise.allSettled([refreshHealth(), refreshSessions()]);
+  if (!state.selectedSession && state.sessions.length === 0) {
+    await createDefaultSession();
+  }
+  render();
+}
+
+async function refreshHealth() {
+  try {
+    state.health = await api("GET", "/healthz");
+  } catch (error) {
+    state.health = null;
+    state.error = errorMessage(error);
+  }
+  renderHealth();
+}
+
+async function refreshSessions() {
+  try {
+    state.sessions = await api("GET", "/v1/sessions");
+    if (!state.selectedSession && state.sessions.length > 0) {
+      await selectSession(state.sessions[0].id);
+    } else if (state.selectedSession) {
+      const stillExists = state.sessions.some((session) => session.id === state.selectedSession.id);
+      if (!stillExists) clearSelectedSession();
+    }
+  } catch (error) {
+    state.error = errorMessage(error);
+  }
+}
+
+async function createDefaultSession() {
+  if (state.running) return;
+  try {
+    const result = await api("POST", "/v1/sessions", {
+      metadata: {
+        source: "web_app",
+      },
+    });
+    state.sessions = await api("GET", "/v1/sessions");
+    await selectSession(result.session_id);
+  } catch (error) {
+    state.error = errorMessage(error);
+    render();
+  }
+}
+
+async function selectSession(sessionId) {
+  state.selectedSession = await api("GET", `/v1/sessions/${encodeURIComponent(sessionId)}`);
+  state.selectedRun = null;
+  state.runEvents = new Map();
+  state.liveEvents = [];
+  state.pendingInput = "";
+  await refreshRuns();
+  render();
+}
+
+async function archiveSelectedSession() {
+  if (!state.selectedSession || state.running) return;
+  try {
+    await api("DELETE", `/v1/sessions/${encodeURIComponent(state.selectedSession.id)}`);
+    clearSelectedSession();
+    await refreshSessions();
+  } catch (error) {
+    state.error = errorMessage(error);
+  }
+  render();
+}
+
+function clearSelectedSession() {
+  state.selectedSession = null;
+  state.runs = [];
+  state.selectedRun = null;
+  state.runEvents = new Map();
+  state.liveEvents = [];
+  state.activeRunId = null;
+  state.pendingInput = "";
+}
+
+async function refreshRuns() {
+  if (!state.selectedSession) return;
+  state.runs = await api(
+    "GET",
+    `/v1/sessions/${encodeURIComponent(state.selectedSession.id)}/runs`,
+  );
+  await refreshRunEvents();
+  if (!state.selectedRun && state.runs.length > 0) state.selectedRun = state.runs[0];
+}
+
+async function selectRun(runId) {
+  if (!state.selectedSession) return;
+  state.selectedRun = await api(
+    "GET",
+    `/v1/sessions/${encodeURIComponent(state.selectedSession.id)}/runs/${encodeURIComponent(runId)}`,
+  );
+  await refreshRunEvents([state.selectedRun]);
+  render();
+}
+
+async function refreshRunEvents(runs = state.runs) {
+  if (!state.selectedSession) return;
+  await Promise.all(
+    runs.map(async (run) => {
+      if (!run.id || state.runEvents.has(run.id)) return;
+      const events = await api(
+        "GET",
+        `/v1/sessions/${encodeURIComponent(state.selectedSession.id)}/runs/${encodeURIComponent(run.id)}/events`,
+      );
+      state.runEvents.set(run.id, events);
+    }),
+  );
+}
+
+async function startRun(event) {
+  event.preventDefault();
+  if (state.running) return;
+  if (!state.selectedSession) {
+    await createDefaultSession();
+  }
+  if (!state.selectedSession) return;
+
+  const input = els.runInput.value.trim();
+  if (!input) return;
+
+  state.liveEvents = [];
+  state.selectedRun = {
+    input,
+    status: "running",
+  };
+  state.pendingInput = input;
+  state.activeRunId = null;
+  state.running = true;
+  state.error = "";
+  render();
+
+  const body = {
+    input,
+    stream: els.streamToggle.checked,
+  };
+
+  try {
+    if (body.stream) {
+      await streamRun(body);
+    } else {
+      const run = await api(
+        "POST",
+        `/v1/sessions/${encodeURIComponent(state.selectedSession.id)}/runs`,
+        body,
+      );
+      state.selectedRun = run;
+      state.activeRunId = run.id;
+      await afterRunFinished(run.id);
+    }
+    els.runInput.value = "";
+  } catch (error) {
+    state.error = errorMessage(error);
+  } finally {
+    state.running = false;
+    render();
+  }
+}
+
+async function streamRun(body) {
+  const path = `/v1/sessions/${encodeURIComponent(state.selectedSession.id)}/runs`;
+  const response = await fetch(path, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "text/event-stream",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  if (!response.body) {
+    throw new Error("stream response body is empty");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const frames = buffer.split("\n\n");
+    buffer = frames.pop() || "";
+    for (const frame of frames) {
+      handleSseFrame(frame);
+    }
+  }
+
+  if (buffer.trim()) handleSseFrame(buffer);
+  if (state.activeRunId) {
+    await afterRunFinished(state.activeRunId);
+  } else {
+    await refreshRuns();
+  }
+}
+
+function handleSseFrame(frame) {
+  const parsed = parseSseFrame(frame);
+  if (!parsed) return;
+
+  if (parsed.event === "run_accepted") {
+    state.activeRunId = parsed.data.run_id;
+    state.selectedRun = {
+      id: parsed.data.run_id,
+      session_id: parsed.data.session_id,
+      status: "running",
+      input: state.pendingInput,
+    };
+  } else if (parsed.event === "error") {
+    state.error = parsed.data.message || JSON.stringify(parsed.data);
+  } else {
+    state.liveEvents.push({
+      name: parsed.event,
+      data: parsed.data,
+      at: Date.now(),
+    });
+  }
+
+  render();
+}
+
+async function afterRunFinished(runId) {
+  await refreshRuns();
+  await selectRun(runId);
+  state.liveEvents = [];
+  state.pendingInput = "";
+}
+
+async function api(method, path, body) {
+  const options = { method, headers: {} };
+  if (body !== null && body !== undefined) {
+    options.headers["content-type"] = "application/json";
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(path, options);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `${method} ${path} failed`);
+  }
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+function parseSseFrame(frame) {
+  let event = "message";
+  const data = [];
+  for (const line of frame.split(/\r?\n/)) {
+    if (line.startsWith("event:")) event = line.slice(6).trim();
+    if (line.startsWith("data:")) data.push(line.slice(5).trimStart());
+  }
+  if (data.length === 0) return null;
+  const raw = data.join("\n");
+  try {
+    return { event, data: JSON.parse(raw) };
+  } catch {
+    return { event, data: raw };
+  }
+}
+
+function render() {
+  renderHealth();
+  renderSelectedSession();
+  renderControls();
+  renderMessages();
+}
+
+function renderHealth() {
+  const dot = state.health ? "status-ok" : state.error ? "status-error" : "status-muted";
+  const text = state.health ? `ok · tools ${state.health.tool_count}` : state.error ? "error" : "healthz";
+  els.healthStatus.innerHTML = `<span class="status-dot ${dot}"></span><span>${escapeHtml(text)}</span>`;
+}
+
+function renderSelectedSession() {
+  if (!state.selectedSession) {
+    els.selectedSessionTitle.textContent = "准备 session";
+    els.selectedSessionMeta.textContent = state.error || "正在连接 Gateway";
+    return;
+  }
+  els.selectedSessionTitle.textContent = shorten(state.selectedSession.id, 42);
+  els.selectedSessionMeta.textContent = `${state.selectedSession.model} · ${state.selectedSession.status}`;
+}
+
+function renderControls() {
+  const hasSession = Boolean(state.selectedSession);
+  const visibleRunId = state.activeRunId || (state.selectedRun && state.selectedRun.id);
+  els.startRunButton.disabled = !hasSession || state.running;
+  els.runInput.disabled = !hasSession || state.running;
+  els.archiveSessionButton.disabled = !hasSession || state.running;
+  els.refreshSessionButton.disabled = !hasSession;
+  els.activeRunLabel.textContent = state.running
+    ? visibleRunId || "running"
+    : visibleRunId || "idle";
+}
+
+function renderMessages() {
+  const items = conversationItems();
+  if (items.length === 0) {
+    els.messagesList.innerHTML = `<div class="empty">发送一条任务开始。</div>`;
+    return;
+  }
+
+  els.messagesList.innerHTML = items.map(renderMessage).join("");
+  if (state.running) {
+    els.threadScroll.scrollTop = els.threadScroll.scrollHeight;
+  }
+}
+
+function conversationItems() {
+  const items = [];
+  const runs = [...state.runs].sort((a, b) => (a.started_at || 0) - (b.started_at || 0));
+
+  for (const run of runs) {
+    items.push(...itemsForRun(run, eventsForRun(run)));
+  }
+
+  if (state.running && state.selectedRun && !state.selectedRun.id) {
+    items.push(...itemsForRun(state.selectedRun, state.liveEvents));
+  } else if (state.running && state.activeRunId && !state.runs.some((run) => run.id === state.activeRunId)) {
+    items.push(...itemsForRun(state.selectedRun, state.liveEvents));
+  }
+
+  if (state.running && !items.some((item) => item.pending)) {
+    items.push({
+      kind: "thinking",
+      role: "Agent 思考",
+      content: "正在思考",
+      pending: true,
+    });
+  }
+
+  if (state.error) {
+    items.push({
+      kind: "error",
+      role: "错误",
+      content: state.error,
+    });
+  }
+
+  return items;
+}
+
+function itemsForRun(run, events) {
+  const items = [];
+  const input = (run && run.input) || state.pendingInput;
+  if (input) {
+    items.push({
+      kind: "user",
+      role: "user",
+      content: input,
+    });
+  }
+  items.push(...displayItemsFromEvents(events));
+  return items;
+}
+
+function eventsForRun(run) {
+  if (!run || !run.id) return state.liveEvents;
+  if (run.id === state.activeRunId && state.liveEvents.length > 0) return state.liveEvents;
+  return (state.runEvents.get(run.id) || []).map((event) => ({
+    name: event.event_type,
+    data: event.payload,
+    at: event.ts,
+  }));
+}
+
+function displayItemsFromEvents(events) {
+  const stepFinishSteps = new Set();
+  for (const event of events) {
+    const variant = variantOf(event.data);
+    if (variant.name === "StepFinish") {
+      const step = variant.value.event;
+      if (step && step.step) stepFinishSteps.add(step.step);
+    }
+  }
+
+  const items = [];
+  const partialTextByStep = new Map();
+  const toolStepCandidates = new Set();
+  const liveToolItems = new Map();
+  let sawDone = false;
+
+  for (const event of events) {
+    const variant = variantOf(event.data);
+    if (variant.name === "Model") {
+      collectModelDelta(variant.value, partialTextByStep, toolStepCandidates);
+      continue;
+    }
+    if (variant.name === "StepFinish") {
+      items.push(...itemsFromStep(variant.value.event));
+    } else if (variant.name === "ToolCallStart") {
+      const start = variant.value.event;
+      if (!stepFinishSteps.has(start.step)) {
+        pushPartialStepItem(items, partialTextByStep, toolStepCandidates, start.step);
+        const item = toolUseItem(start.tool_call, null, start.step);
+        liveToolItems.set(start.tool_call.call_id, item);
+        items.push(item);
+      }
+    } else if (variant.name === "ToolCallFinish") {
+      const finish = variant.value.event;
+      if (!stepFinishSteps.has(finish.step)) {
+        const item = liveToolItems.get(finish.tool_call.call_id);
+        if (item) {
+          item.result = finish.tool_result;
+          item.content = toolUseContent(finish.tool_call, finish.tool_result);
+        } else {
+          items.push(toolUseItem(finish.tool_call, finish.tool_result, finish.step));
+        }
+      }
+    } else if (variant.name === "Done") {
+      sawDone = true;
+    }
+  }
+
+  for (const [step] of partialTextByStep) {
+    if (!stepFinishSteps.has(step)) {
+      pushPartialStepItem(items, partialTextByStep, toolStepCandidates, step);
+    }
+  }
+
+  if (items.length === 0 && sawDone) {
+    const done = events
+      .map((event) => variantOf(event.data))
+      .find((variant) => variant.name === "Done");
+    const output = done && done.value.output && done.value.output.output_text;
+    if (output) {
+      items.push({
+        kind: "final",
+        role: "结果",
+        content: output,
+      });
+    }
+  }
+
+  return items;
+}
+
+function collectModelDelta(model, partialTextByStep, toolStepCandidates) {
+  if (!model || !model.event) return;
+  const streamEvent = variantOf(model.event);
+  if (streamEvent.name === "TextDelta") {
+    const text = streamEvent.value.text || "";
+    if (!text) return;
+    partialTextByStep.set(model.step, `${partialTextByStep.get(model.step) || ""}${text}`);
+  } else if (streamEvent.name === "ToolCallReady") {
+    toolStepCandidates.add(model.step);
+  }
+}
+
+function pushPartialStepItem(items, partialTextByStep, toolStepCandidates, step) {
+  const text = (partialTextByStep.get(step) || "").trim();
+  if (!text) return;
+  items.push({
+    kind: toolStepCandidates.has(step) ? "thinking" : "final",
+    role: toolStepCandidates.has(step) ? "Agent 思考" : "结果",
+    meta: `step ${step}`,
+    content: text,
+    pending: true,
+  });
+  partialTextByStep.delete(step);
+}
+
+function itemsFromStep(step) {
+  if (!step) return [];
+  const items = [];
+  const toolCalls = step.tool_calls || [];
+  const toolResults = step.tool_results || [];
+  const thought = stepThought(step);
+
+  if (toolCalls.length > 0) {
+    items.push({
+      kind: "thinking",
+      role: "Agent 思考",
+      meta: `step ${step.step}`,
+      content: thought || "决定调用工具。",
+    });
+    for (const call of toolCalls) {
+      const result = toolResults.find((candidate) => candidate.call_id === call.call_id);
+      items.push(toolUseItem(call, result, step.step));
+    }
+  } else if (step.output_text) {
+    items.push({
+      kind: "final",
+      role: "结果",
+      meta: `step ${step.step}`,
+      content: step.output_text,
+    });
+  }
+
+  return items;
+}
+
+function stepThought(step) {
+  if (step.reasoning_text && step.reasoning_text.trim()) return step.reasoning_text.trim();
+  const reasoning = (step.reasoning_parts || [])
+    .map((part) => part.text || "")
+    .join("")
+    .trim();
+  if (reasoning) return reasoning;
+  if (step.output_text && step.output_text.trim()) return step.output_text.trim();
+  return "";
+}
+
+function toolUseItem(call, result, step) {
+  return {
+    kind: "tool",
+    role: "工具调用",
+    meta: `${call.tool_name} · step ${step}`,
+    content: toolUseContent(call, result),
+    result,
+  };
+}
+
+function toolUseContent(call, result) {
+  return [
+    "参数",
+    prettyJson(call.args_json || {}),
+    "",
+    "结果",
+    result ? prettyJson(result.output_json) : "等待工具返回结果。",
+  ].join("\n");
+}
+
+function renderMessage(item) {
+  const meta = item.meta ? `<span class="message-meta">${escapeHtml(item.meta)}</span>` : "";
+  const pending = item.pending ? " thinking-pulse" : "";
+  if (item.kind === "tool") {
+    const [args, result] = splitToolContent(item.content);
+    return `
+      <article class="message-row tool">
+        <div class="message-role">${escapeHtml(item.role)}</div>
+        <details class="tool-card">
+          <summary>
+            <span>
+              ${meta}
+              <span class="tool-title">参数</span>
+              <code>${escapeHtml(args)}</code>
+            </span>
+          </summary>
+          <pre>${escapeHtml(result)}</pre>
+        </details>
+      </article>
+    `;
+  }
+  return `
+    <article class="message-row ${escapeAttr(item.kind)}">
+      <div class="message-role">${escapeHtml(item.role)}</div>
+      <div class="message-content${pending}">${meta}${escapeHtml(item.content)}</div>
+    </article>
+  `;
+}
+
+function splitToolContent(content) {
+  const marker = "\n\n结果\n";
+  const index = content.indexOf(marker);
+  if (index === -1) return [content.replace(/^参数\n/, ""), ""];
+  return [
+    content.slice(0, index).replace(/^参数\n/, ""),
+    content.slice(index + marker.length),
+  ];
+}
+
+function prettyJson(value) {
+  if (value === undefined || value === null) return "null";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value, null, 2);
+}
+
+function errorMessage(error) {
+  return String(error && error.message ? error.message : error);
+}
+
+function variantOf(value) {
+  if (!value || typeof value !== "object") return { name: "", value: null };
+  const keys = Object.keys(value);
+  if (keys.length === 0) return { name: "", value: null };
+  return { name: keys[0], value: value[keys[0]] };
+}
+
+function shorten(value, max) {
+  const text = String(value || "");
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value);
+}

--- a/examples/remote_agent/static/style.css
+++ b/examples/remote_agent/static/style.css
@@ -1,0 +1,547 @@
+:root {
+  color-scheme: dark;
+  --bg: #121212;
+  --bar: #171717;
+  --panel: #242424;
+  --panel-2: #2b2b2b;
+  --line: #333333;
+  --line-soft: #252525;
+  --text: #eeeeee;
+  --muted: #9a9a9a;
+  --muted-2: #6f6f6f;
+  --primary: #f27a22;
+  --green: #39d27d;
+  --red: #ff5f58;
+  --blue: #8ab4f8;
+  --mono: "SFMono-Regular", "Cascadia Mono", "Liberation Mono", Menlo, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --radius: 22px;
+  --radius-sm: 10px;
+  --shadow: 0 18px 50px rgb(0 0 0 / 34%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  letter-spacing: 0;
+}
+
+button,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled,
+textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: 58px 1fr;
+}
+
+.topbar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 18px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--line-soft);
+  background: var(--bar);
+}
+
+.window-controls,
+.brand,
+.topbar-actions,
+.thread-actions,
+.composer-actions {
+  display: flex;
+  align-items: center;
+}
+
+.window-controls {
+  gap: 9px;
+}
+
+.window-controls span {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.window-controls span:nth-child(1) {
+  background: #ff5f57;
+}
+
+.window-controls span:nth-child(2) {
+  background: #ffbd2e;
+}
+
+.window-controls span:nth-child(3) {
+  background: #28c840;
+}
+
+.brand {
+  gap: 10px;
+  min-width: 0;
+}
+
+.brand-mark {
+  width: 26px;
+  height: 26px;
+  border: 1px solid #777777;
+  border-radius: 7px;
+  background:
+    linear-gradient(135deg, transparent 0 44%, #d7d7d7 45% 55%, transparent 56%),
+    #202020;
+}
+
+.brand h1,
+.thread h2 {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.15;
+  font-weight: 680;
+}
+
+.brand p,
+.thread-title span {
+  margin: 3px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.topbar-actions {
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.status-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #222222;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--muted-2);
+}
+
+.status-ok {
+  background: var(--green);
+}
+
+.status-error {
+  background: var(--red);
+}
+
+.status-muted {
+  background: var(--muted-2);
+}
+
+.workspace {
+  min-height: 0;
+  height: calc(100vh - 58px);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.thread {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  width: min(100%, 1120px);
+  margin: 0 auto;
+  padding: 18px 24px;
+}
+
+.thread-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding-bottom: 18px;
+}
+
+.thread-title {
+  min-width: 0;
+}
+
+.thread-title h2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thread-actions {
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.run-state {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.button,
+.icon-button,
+.send-button {
+  border: 1px solid var(--line);
+  color: var(--text);
+  transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+
+.button {
+  min-height: 32px;
+  padding: 0 11px;
+  border-radius: var(--radius-sm);
+  background: #222222;
+}
+
+.button.quiet {
+  background: transparent;
+}
+
+.button.danger {
+  border-color: rgb(255 95 88 / 44%);
+  color: var(--red);
+  background: #2a1919;
+}
+
+.button.small {
+  min-height: 30px;
+  font-size: 12px;
+}
+
+.button:hover,
+.icon-button:hover {
+  border-color: #555555;
+  background: #2d2d2d;
+}
+
+.button:active,
+.icon-button:active,
+.send-button:active {
+  transform: translateY(1px);
+}
+
+.icon-button,
+.send-button {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #232323;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.send-button {
+  width: 38px;
+  height: 38px;
+  border-color: #f0f0f0;
+  background: #f1f1f1;
+  color: #151515;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  color: var(--text);
+  outline: none;
+  resize: vertical;
+  line-height: 1.5;
+}
+
+textarea::placeholder {
+  color: var(--muted-2);
+}
+
+textarea:focus,
+button:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.thread-scroll {
+  min-height: 0;
+  overflow: auto;
+  padding: 4px 4px 20px;
+}
+
+.message-stack {
+  display: grid;
+  gap: 22px;
+  max-width: 940px;
+  margin: 0 auto;
+}
+
+.message-row {
+  display: grid;
+  grid-template-columns: 112px minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.message-role {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.6;
+  text-align: right;
+}
+
+.message-content {
+  min-width: 0;
+  color: #e8e8e8;
+  font-size: 15px;
+  line-height: 1.72;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.message-row.user .message-content,
+.message-row.final .message-content {
+  font-weight: 560;
+}
+
+.tool-card {
+  padding: 13px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: #1d1d1d;
+  color: #dedede;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.tool-card summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+.tool-card summary::-webkit-details-marker {
+  display: none;
+}
+
+.tool-card summary::before {
+  content: "›";
+  display: inline-block;
+  margin-right: 8px;
+  color: var(--muted);
+  transition: transform 140ms ease;
+}
+
+.tool-card[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.tool-card code {
+  display: block;
+  margin-top: 7px;
+  color: #dedede;
+  font-family: var(--mono);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.tool-card pre {
+  margin: 12px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+  color: #dedede;
+  font-family: var(--mono);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.message-row.tool .message-role {
+  color: var(--primary);
+}
+
+.message-meta {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--muted-2);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.empty {
+  max-width: 940px;
+  margin: 8vh auto 0;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.thinking-pulse::after {
+  content: "";
+  display: inline-block;
+  width: 1.2em;
+  text-align: left;
+  animation: dots 1.2s steps(4, end) infinite;
+}
+
+@keyframes dots {
+  0% {
+    content: "";
+  }
+  25% {
+    content: ".";
+  }
+  50% {
+    content: "..";
+  }
+  75%,
+  100% {
+    content: "...";
+  }
+}
+
+.composer {
+  max-width: 940px;
+  width: 100%;
+  margin: 0 auto;
+  padding-top: 12px;
+}
+
+.composer textarea {
+  min-height: 102px;
+  max-height: 240px;
+  padding: 18px 20px 58px;
+  box-shadow: var(--shadow);
+}
+
+.composer-actions {
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: -50px;
+  padding: 0 14px 12px 16px;
+  pointer-events: none;
+}
+
+.composer-actions > * {
+  pointer-events: auto;
+}
+
+.toggle {
+  display: inline-flex;
+  grid-auto-flow: column;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.toggle input {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--primary);
+}
+
+@media (max-width: 760px) {
+  body {
+    overflow: auto;
+  }
+
+  .app-shell {
+    min-height: 100vh;
+    grid-template-rows: auto 1fr;
+  }
+
+  .topbar {
+    grid-template-columns: 1fr auto;
+    gap: 10px;
+    padding: 12px 14px;
+  }
+
+  .window-controls {
+    display: none;
+  }
+
+  .topbar-actions {
+    grid-column: 1 / -1;
+    justify-content: space-between;
+  }
+
+  .workspace {
+    height: auto;
+    min-height: calc(100vh - 84px);
+    overflow: visible;
+  }
+
+  .thread {
+    min-height: calc(100vh - 84px);
+    padding: 14px;
+  }
+
+  .thread-head {
+    display: grid;
+  }
+
+  .thread-actions {
+    justify-content: start;
+    flex-wrap: wrap;
+  }
+
+  .message-row {
+    grid-template-columns: 1fr;
+    gap: 5px;
+  }
+
+  .message-role {
+    text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -21,7 +21,7 @@
 //! Adapters are created through provider clients which handle configuration and
 //! HTTP client setup:
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use aquaregia::providers::{anthropic, google, openai, openai_compatible};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -52,12 +52,16 @@ use crate::error::Error;
 use crate::types::{ChatRequest, ChatResponse, TextStream};
 
 /// Anthropic provider adapter implementation.
+#[cfg(feature = "anthropic")]
 pub mod anthropic;
 /// Google provider adapter implementation.
+#[cfg(feature = "google")]
 pub mod google;
 /// OpenAI provider adapter implementation.
+#[cfg(feature = "openai")]
 pub mod openai;
 /// OpenAI-compatible provider adapter implementation.
+#[cfg(feature = "openai-compatible")]
 pub mod openai_compatible;
 
 /// Provider adapter contract used by provider clients.
@@ -146,6 +150,11 @@ pub(crate) fn merge_provider_options(
 /// API at request time; this helper is only for top-level categories the
 /// adapter has no representation for (e.g. PDFs in a chat-completions-only
 /// path, or arbitrary types in an image-only path).
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "openai-compatible"
+))]
 pub(crate) fn unsupported_media_type(slug: &str, media_type: &str) -> crate::error::Error {
     crate::error::Error::new(
         crate::error::ErrorCode::InvalidRequest,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Example
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use aquaregia::{providers::openai, tool};
 //! use serde_json::json;
 //!
@@ -416,7 +416,7 @@ impl AgentBuilder {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "openai"))]
 mod tests {
     use crate::providers;
     use serde_json::json;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -55,6 +55,50 @@ use crate::types::{
     ToolErrorPolicy, validate_model_ref, validate_sampling,
 };
 
+mod sealed {
+    pub trait Sealed {}
+
+    impl<I, T> Sealed for I
+    where
+        I: IntoIterator<Item = T>,
+        T: crate::tool::IntoTool,
+    {
+    }
+
+    #[cfg(feature = "mcp")]
+    impl Sealed for crate::mcp::McpConnection {}
+}
+
+/// Values that can be registered through [`AgentBuilder::tools`].
+///
+/// Normal tool collections are registered as static tools. With the `mcp`
+/// feature enabled, `McpConnection` is registered as a live MCP tool source
+/// that updates when the server sends
+/// `notifications/tools/list_changed`.
+pub trait IntoAgentTools: sealed::Sealed {
+    #[doc(hidden)]
+    fn __apply_to_agent_builder(self, builder: AgentBuilder) -> AgentBuilder;
+}
+
+impl<I, T> IntoAgentTools for I
+where
+    I: IntoIterator<Item = T>,
+    T: IntoTool,
+{
+    fn __apply_to_agent_builder(self, mut builder: AgentBuilder) -> AgentBuilder {
+        builder.template = builder.template.tools(self);
+        builder
+    }
+}
+
+#[cfg(feature = "mcp")]
+impl IntoAgentTools for crate::mcp::McpConnection {
+    fn __apply_to_agent_builder(self, mut builder: AgentBuilder) -> AgentBuilder {
+        builder.template = builder.template.tool_source(Arc::new(self));
+        builder
+    }
+}
+
 /// Multi-step tool-using agent bound to one provider and one default model.
 ///
 /// The agent implements a tool-use loop that:
@@ -210,13 +254,14 @@ impl AgentBuilder {
     }
 
     /// Registers tools available to the model.
-    pub fn tools<I, T>(mut self, tools: I) -> Self
+    ///
+    /// Pass a collection of local tools for a static snapshot, or an MCP
+    /// connection for a live tool set when the `mcp` feature is enabled.
+    pub fn tools<T>(self, tools: T) -> Self
     where
-        I: IntoIterator<Item = T>,
-        T: IntoTool,
+        T: IntoAgentTools,
     {
-        self.template = self.template.tools(tools);
-        self
+        tools.__apply_to_agent_builder(self)
     }
 
     /// Sets the max number of agent loop steps.

--- a/src/client.rs
+++ b/src/client.rs
@@ -52,14 +52,14 @@ use crate::adapters::openai_compatible::{
 use crate::embed::{EmbedRequest, EmbedResponse, validate_embed_request};
 use crate::error::{Error, ErrorCode};
 use crate::partial_json::repair_json;
-use crate::tool::{ToolExecError, ToolRegistry};
+use crate::tool::{Tool, ToolExecError, ToolRegistry};
 use crate::types::{
     AgentFinish, AgentOutput, AgentPrepareStep, AgentPreparedStep, AgentStart, AgentStep,
     AgentStepStart, AgentStream, AgentStreamEvent, AgentToolCallFinish, AgentToolCallStart,
     ChatRequest, ChatResponse, ContentPart, FinishReason, Message, ObjectResponse, ObjectStream,
     OutputSchema, ReasoningPart, RunTools, StreamEvent, StreamObjectEvent, TextPart, TextStream,
-    ToolCall, ToolErrorPolicy, ToolResult, Usage, validate_messages, validate_model_ref,
-    validate_sampling,
+    ToolCall, ToolErrorPolicy, ToolResult, ToolSourceRef, Usage, validate_messages,
+    validate_model_ref, validate_sampling,
 };
 
 mod sealed {
@@ -548,11 +548,23 @@ impl Client {
         Ok(Box::pin(object_stream))
     }
 
+    async fn resolve_tools(
+        tools: &[Tool],
+        tool_sources: &[ToolSourceRef],
+    ) -> Result<Vec<Tool>, Error> {
+        let mut resolved = tools.to_vec();
+        for source in tool_sources {
+            resolved.extend(source.tools().await?);
+        }
+        Ok(resolved)
+    }
+
     pub(crate) async fn run_tools(&self, req: RunTools) -> Result<AgentOutput, Error> {
         let RunTools {
             model,
             messages,
             tools,
+            tool_sources,
             max_steps,
             temperature,
             top_p,
@@ -578,13 +590,13 @@ impl Client {
         let mut messages = messages;
         let mut usage_total = Usage::default();
         let mut step_results = Vec::new();
-        let mut tool_registry = ToolRegistry::from_tools(tools.clone())?;
+        let start_tools = Self::resolve_tools(&tools, &tool_sources).await?;
 
         if let Some(callback) = &on_start {
             callback(&AgentStart {
                 model_id: model.clone(),
                 messages: messages.clone(),
-                tool_count: tools.len(),
+                tool_count: start_tools.len(),
                 max_steps: resolved_max_steps,
             });
         }
@@ -612,7 +624,7 @@ impl Client {
             let mut prepared_step = AgentPreparedStep {
                 model: model.clone(),
                 messages: messages.clone(),
-                tools: tools.clone(),
+                tools: Self::resolve_tools(&tools, &tool_sources).await?,
                 temperature,
                 max_output_tokens,
                 stop_sequences: stop_sequences.clone(),
@@ -622,14 +634,14 @@ impl Client {
                     step,
                     model: model.clone(),
                     messages: messages.clone(),
-                    tools: tools.clone(),
+                    tools: prepared_step.tools.clone(),
                     temperature,
                     max_output_tokens,
                     stop_sequences: stop_sequences.clone(),
                     previous_steps: step_results.clone(),
                 });
-                tool_registry = ToolRegistry::from_tools(prepared_step.tools.clone())?;
             }
+            let tool_registry = ToolRegistry::from_tools(prepared_step.tools.clone())?;
 
             validate_messages(&prepared_step.messages)?;
 
@@ -756,6 +768,7 @@ impl Client {
             model,
             messages,
             tools,
+            tool_sources,
             max_steps,
             temperature,
             top_p,
@@ -775,18 +788,18 @@ impl Client {
         } = req;
 
         let resolved_max_steps = max_steps.unwrap_or(self.default_max_steps);
-        let mut tool_registry = ToolRegistry::from_tools(tools.clone())?;
         let client = self;
 
         let stream = async_stream::try_stream! {
             let mut messages = messages;
             let mut usage_total = Usage::default();
             let mut step_results = Vec::new();
+            let start_tools = Self::resolve_tools(&tools, &tool_sources).await?;
 
             let start_event = AgentStart {
                 model_id: model.clone(),
                 messages: messages.clone(),
-                tool_count: tools.len(),
+                tool_count: start_tools.len(),
                 max_steps: resolved_max_steps,
             };
             if let Some(callback) = &on_start {
@@ -817,7 +830,7 @@ impl Client {
                 let mut prepared_step = AgentPreparedStep {
                     model: model.clone(),
                     messages: messages.clone(),
-                    tools: tools.clone(),
+                    tools: Self::resolve_tools(&tools, &tool_sources).await?,
                     temperature,
                     max_output_tokens,
                     stop_sequences: stop_sequences.clone(),
@@ -827,14 +840,14 @@ impl Client {
                         step,
                         model: model.clone(),
                         messages: messages.clone(),
-                        tools: tools.clone(),
+                        tools: prepared_step.tools.clone(),
                         temperature,
                         max_output_tokens,
                         stop_sequences: stop_sequences.clone(),
                         previous_steps: step_results.clone(),
                     });
-                    tool_registry = ToolRegistry::from_tools(prepared_step.tools.clone())?;
                 }
+                let tool_registry = ToolRegistry::from_tools(prepared_step.tools.clone())?;
 
                 validate_messages(&prepared_step.messages)?;
 
@@ -1335,7 +1348,25 @@ async fn execute_tool_calls(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    use crate::error::Error;
+    use crate::tool::Tool;
+    use crate::types::{ToolSource, ToolSourceRef};
+
     use super::Client;
+
+    struct StaticToolSource(Vec<Tool>);
+
+    #[async_trait]
+    impl ToolSource for StaticToolSource {
+        async fn tools(&self) -> Result<Vec<Tool>, Error> {
+            Ok(self.0.clone())
+        }
+    }
 
     #[test]
     fn openai_builder_builds() {
@@ -1353,5 +1384,26 @@ mod tests {
             .build()
             .expect("client should build");
         let _ = client;
+    }
+
+    #[tokio::test]
+    async fn resolve_tools_merges_static_tools_and_sources() {
+        let static_tool = crate::tool("static_tool")
+            .description("static")
+            .execute_raw(|_| async { Ok(json!({"ok": true})) });
+        let dynamic_tool = crate::tool("dynamic_tool")
+            .description("dynamic")
+            .execute_raw(|_| async { Ok(json!({"ok": true})) });
+        let source: ToolSourceRef = Arc::new(StaticToolSource(vec![dynamic_tool]));
+
+        let tools = Client::resolve_tools(&[static_tool], &[source])
+            .await
+            .expect("tools should resolve");
+
+        let names = tools
+            .into_iter()
+            .map(|tool| tool.descriptor.name)
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["static_tool", "dynamic_tool"]);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@
 //!
 //! ## Example
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use aquaregia::providers::openai;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -43,9 +43,13 @@ use futures_util::stream::{FuturesUnordered, StreamExt};
 use tokio::time::sleep;
 
 use crate::adapters::ModelAdapter;
+#[cfg(feature = "anthropic")]
 use crate::adapters::anthropic::{AnthropicAdapter, AnthropicAdapterSettings};
+#[cfg(feature = "google")]
 use crate::adapters::google::{GoogleAdapter, GoogleAdapterSettings};
+#[cfg(feature = "openai")]
 use crate::adapters::openai::{OpenAiAdapter, OpenAiAdapterSettings};
+#[cfg(feature = "openai-compatible")]
 use crate::adapters::openai_compatible::{
     OpenAiCompatibleAdapter, OpenAiCompatibleAdapterSettings,
 };
@@ -64,15 +68,19 @@ use crate::types::{
 
 mod sealed {
     pub trait Sealed {}
+    #[cfg(feature = "openai")]
     impl Sealed for super::OpenAiAdapterSettings {}
+    #[cfg(feature = "anthropic")]
     impl Sealed for super::AnthropicAdapterSettings {}
+    #[cfg(feature = "google")]
     impl Sealed for super::GoogleAdapterSettings {}
+    #[cfg(feature = "openai-compatible")]
     impl Sealed for super::OpenAiCompatibleAdapterSettings {}
 }
 
 /// Provider-settings contract consumed by [`ClientBuilder`].
 ///
-/// This trait is sealed: it is implemented exactly for the four built-in
+/// This trait is sealed: it is implemented for enabled built-in
 /// `*AdapterSettings` types and cannot be implemented downstream. External
 /// providers should add an adapter to the `adapters` module rather
 /// than implementing this trait.
@@ -81,6 +89,7 @@ pub trait BuildProvider: sealed::Sealed {
     fn into_adapter(self, http: Arc<reqwest::Client>) -> Arc<dyn ModelAdapter>;
 }
 
+#[cfg(feature = "openai")]
 impl BuildProvider for OpenAiAdapterSettings {
     fn validate(&self) -> Result<(), Error> {
         if self.api_key.trim().is_empty() {
@@ -96,6 +105,7 @@ impl BuildProvider for OpenAiAdapterSettings {
     }
 }
 
+#[cfg(feature = "anthropic")]
 impl BuildProvider for AnthropicAdapterSettings {
     fn validate(&self) -> Result<(), Error> {
         if self.api_key.trim().is_empty() {
@@ -111,6 +121,7 @@ impl BuildProvider for AnthropicAdapterSettings {
     }
 }
 
+#[cfg(feature = "google")]
 impl BuildProvider for GoogleAdapterSettings {
     fn validate(&self) -> Result<(), Error> {
         if self.api_key.trim().is_empty() {
@@ -126,6 +137,7 @@ impl BuildProvider for GoogleAdapterSettings {
     }
 }
 
+#[cfg(feature = "openai-compatible")]
 impl BuildProvider for OpenAiCompatibleAdapterSettings {
     fn validate(&self) -> Result<(), Error> {
         if self.base_url.trim().is_empty() {
@@ -207,6 +219,7 @@ impl<S: BuildProvider> ClientBuilder<S> {
     }
 }
 
+#[cfg(feature = "openai")]
 impl ClientBuilder<OpenAiAdapterSettings> {
     /// Sets the OpenAI API key (required).
     pub fn api_key(mut self, api_key: impl Into<String>) -> Self {
@@ -221,6 +234,7 @@ impl ClientBuilder<OpenAiAdapterSettings> {
     }
 }
 
+#[cfg(feature = "anthropic")]
 impl ClientBuilder<AnthropicAdapterSettings> {
     /// Sets the Anthropic API key (required).
     pub fn api_key(mut self, api_key: impl Into<String>) -> Self {
@@ -241,6 +255,7 @@ impl ClientBuilder<AnthropicAdapterSettings> {
     }
 }
 
+#[cfg(feature = "google")]
 impl ClientBuilder<GoogleAdapterSettings> {
     /// Sets the Google API key (required).
     pub fn api_key(mut self, api_key: impl Into<String>) -> Self {
@@ -255,6 +270,7 @@ impl ClientBuilder<GoogleAdapterSettings> {
     }
 }
 
+#[cfg(feature = "openai-compatible")]
 impl ClientBuilder<OpenAiCompatibleAdapterSettings> {
     /// Sets the OpenAI-compatible endpoint base URL (required).
     pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
@@ -299,7 +315,7 @@ impl ClientBuilder<OpenAiCompatibleAdapterSettings> {
 ///
 /// Provider-specific public builders produce this internal client:
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// use aquaregia::providers::openai;
 ///
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -320,6 +336,7 @@ impl Client {
     ///
     /// Set the API key with `ClientBuilder::api_key` (required) and optionally
     /// override the endpoint with `ClientBuilder::base_url`.
+    #[cfg(feature = "openai")]
     pub fn openai() -> ClientBuilder<OpenAiAdapterSettings> {
         ClientBuilder::new(OpenAiAdapterSettings::new())
     }
@@ -329,6 +346,7 @@ impl Client {
     /// Set the API key with `ClientBuilder::api_key` (required) and optionally
     /// override the endpoint with `ClientBuilder::base_url` or the version
     /// header with `ClientBuilder::api_version`.
+    #[cfg(feature = "anthropic")]
     pub fn anthropic() -> ClientBuilder<AnthropicAdapterSettings> {
         ClientBuilder::new(AnthropicAdapterSettings::new())
     }
@@ -337,6 +355,7 @@ impl Client {
     ///
     /// Set the API key with `ClientBuilder::api_key` (required) and optionally
     /// override the endpoint with `ClientBuilder::base_url`.
+    #[cfg(feature = "google")]
     pub fn google() -> ClientBuilder<GoogleAdapterSettings> {
         ClientBuilder::new(GoogleAdapterSettings::new())
     }
@@ -346,6 +365,7 @@ impl Client {
     /// Set the base URL with `ClientBuilder::base_url` (required). The bearer
     /// token is optional and configured with `ClientBuilder::api_key` (or
     /// disabled with `ClientBuilder::no_api_key`, which is the default).
+    #[cfg(feature = "openai-compatible")]
     pub fn openai_compatible() -> ClientBuilder<OpenAiCompatibleAdapterSettings> {
         ClientBuilder::new(OpenAiCompatibleAdapterSettings::new())
     }
@@ -383,7 +403,7 @@ impl Client {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
+    /// ```rust,ignore
     /// use aquaregia::embed::EmbedRequest;
     /// use aquaregia::providers::openai;
     ///
@@ -1368,6 +1388,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "openai")]
     #[test]
     fn openai_builder_builds() {
         let client = Client::openai()
@@ -1377,6 +1398,7 @@ mod tests {
         let _ = client;
     }
 
+    #[cfg(feature = "anthropic")]
     #[test]
     fn anthropic_builder_builds() {
         let client = Client::anthropic()

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -9,7 +9,7 @@
 //!
 //! ## Example
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use aquaregia::embed::EmbedRequest;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Error Handling Pattern
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use aquaregia::{ChatRequest, ErrorCode};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@ pub(crate) mod client;
 pub mod embed;
 /// Unified error types and HTTP-to-error mapping helpers.
 pub mod error;
+/// MCP (Model Context Protocol) client integration (requires the `mcp` feature).
+#[cfg(feature = "mcp")]
+pub mod mcp;
 pub(crate) mod partial_json;
 /// Provider-specific client entry points.
 pub mod providers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! ## Quick Start
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use aquaregia::providers::openai;
 //!
 //! #[tokio::main]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,789 @@
+//! MCP (Model Context Protocol) client integration.
+//!
+//! Feature-gated behind `mcp`. Connects to an MCP server, lists its tools, and
+//! adapts each one into an aquaregia [`Tool`] that plugs straight into an
+//! [`Agent`](crate::Agent) via `.tools(...)`. Prompts and resources are exposed
+//! as thin pass-through APIs that return `rmcp` model types. The protocol,
+//! transport, and handshake are handled by the official [`rmcp`] SDK; this
+//! module only maps `rmcp` tools to aquaregia tools and flattens MCP tool
+//! results.
+//!
+//! ```rust,no_run
+//! use aquaregia::providers;
+//! use tokio::process::Command;
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let mcp = aquaregia::mcp::connect_stdio(Command::new("mcp-server-fs")).await?;
+//! let agent = providers::openai_compatible::Client::builder()
+//!     .base_url("https://api.example.com")
+//!     .api_key("api-key")
+//!     .build()?
+//!     .agent("gpt-5.4-mini")
+//!     .tools(mcp.clone())
+//!     .build()?;
+//! let snapshot = mcp.list_tools().await?;
+//! # let _ = (agent, snapshot);
+//! # Ok(())
+//! # }
+//! ```
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rmcp::handler::client::ClientHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, GetPromptRequestParams, PaginatedRequestParams,
+    ReadResourceRequestParams,
+};
+use rmcp::service::{RoleClient, RunningService, ServerSink, ServiceError, ServiceExt};
+use rmcp::transport::{StreamableHttpClientTransport, TokioChildProcess};
+use serde_json::{Value, json};
+use tokio::process::Command;
+
+use crate::error::Error;
+use crate::tool::{Tool, ToolDescriptor, ToolExecError, ToolExecutor};
+use crate::types::ToolSource;
+
+pub use rmcp::model::{
+    ContentBlock, GetPromptResult, Prompt, PromptArgument, PromptMessage, ReadResourceResult,
+    Resource, ResourceContents, ResourceTemplate, Role,
+};
+
+/// MCP request metadata passed through as `_meta`.
+///
+/// This is hidden from the model and sent only to the MCP server, which makes it
+/// suitable for auth tokens, session ids, or other call-scoped transport data.
+pub use rmcp::model::Meta;
+
+/// Default per-call timeout. A never-answered MCP response would otherwise hang
+/// the agent forever; this bounds it into a recoverable [`ToolExecError`].
+pub const DEFAULT_CALL_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Error from establishing or querying an MCP connection.
+///
+/// Errors from individual tool *calls* surface as [`ToolExecError`] inside the
+/// agent loop, not here.
+#[derive(Debug, thiserror::Error)]
+pub enum McpError {
+    /// Failed to spawn the server or complete the MCP handshake.
+    #[error("MCP connect failed: {0}")]
+    Connect(String),
+    /// Failed to fetch the tool list from the server.
+    #[error("MCP list tools failed: {0}")]
+    ListTools(String),
+    /// Failed to fetch the prompt list from the server.
+    #[error("MCP list prompts failed: {0}")]
+    ListPrompts(String),
+    /// Failed to fetch a prompt from the server.
+    #[error("MCP get prompt failed: {0}")]
+    GetPrompt(String),
+    /// Failed to fetch the resource list from the server.
+    #[error("MCP list resources failed: {0}")]
+    ListResources(String),
+    /// Failed to fetch the resource template list from the server.
+    #[error("MCP list resource templates failed: {0}")]
+    ListResourceTemplates(String),
+    /// Failed to read a resource from the server.
+    #[error("MCP read resource failed: {0}")]
+    ReadResource(String),
+    /// The provided request arguments cannot be encoded as MCP arguments.
+    #[error("{0}")]
+    InvalidArguments(String),
+    /// The connection has already closed.
+    #[error("MCP connection is disconnected")]
+    Disconnected,
+    /// A tool call exceeded the configured timeout.
+    #[error("MCP tool call timed out")]
+    CallTimeout,
+}
+
+impl McpError {
+    fn into_tool_error(self) -> ToolExecError {
+        match self {
+            McpError::CallTimeout => ToolExecError::Timeout,
+            other => ToolExecError::Execution(other.to_string()),
+        }
+    }
+}
+
+type ToolCache = Arc<tokio::sync::RwLock<Vec<Tool>>>;
+type SharedToolConfig = Arc<RwLock<McpToolConfig>>;
+
+#[derive(Clone)]
+struct McpToolConfig {
+    timeout: Option<Duration>,
+    meta: Option<Meta>,
+}
+
+impl Default for McpToolConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Some(DEFAULT_CALL_TIMEOUT),
+            meta: None,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct McpClientHandler {
+    tools: ToolCache,
+    config: SharedToolConfig,
+}
+
+impl McpClientHandler {
+    fn new() -> Self {
+        Self {
+            tools: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+            config: Arc::new(RwLock::new(McpToolConfig::default())),
+        }
+    }
+
+    async fn refresh_tools(&self, peer: ServerSink) -> Result<Vec<Tool>, ServiceError> {
+        let raw_tools = peer.list_all_tools().await?;
+        let tools = raw_tools
+            .into_iter()
+            .map(|tool| build_tool_from_mcp(peer.clone(), tool, Arc::clone(&self.config)))
+            .collect::<Vec<_>>();
+        *self.tools.write().await = tools.clone();
+        Ok(tools)
+    }
+}
+
+impl ClientHandler for McpClientHandler {
+    async fn on_tool_list_changed(&self, context: rmcp::service::NotificationContext<RoleClient>) {
+        let _ = self.refresh_tools(context.peer).await;
+    }
+}
+
+/// An active MCP connection.
+///
+/// Must be kept alive while the [`Tool`]s it produces are in use: dropping it
+/// closes the connection, after which those tools' calls fail with a
+/// [`ToolExecError`].
+#[derive(Clone)]
+pub struct McpConnection {
+    service: Arc<RunningService<RoleClient, McpClientHandler>>,
+    tools: ToolCache,
+    config: SharedToolConfig,
+}
+
+/// Connect to a local MCP server launched as a child process (stdio transport).
+pub async fn connect_stdio(command: Command) -> Result<McpConnection, McpError> {
+    let transport =
+        TokioChildProcess::new(command).map_err(|e| McpError::Connect(e.to_string()))?;
+    let handler = McpClientHandler::new();
+    let tools = Arc::clone(&handler.tools);
+    let config = Arc::clone(&handler.config);
+    let service = handler
+        .serve(transport)
+        .await
+        .map_err(|e| McpError::Connect(e.to_string()))?;
+    let connection = McpConnection {
+        service: Arc::new(service),
+        tools,
+        config,
+    };
+    let _ = connection.refresh_tools().await;
+    Ok(connection)
+}
+
+/// Connect to a remote MCP server over Streamable HTTP.
+pub async fn connect_http(url: impl Into<String>) -> Result<McpConnection, McpError> {
+    let transport = StreamableHttpClientTransport::from_uri(url.into());
+    let handler = McpClientHandler::new();
+    let tools = Arc::clone(&handler.tools);
+    let config = Arc::clone(&handler.config);
+    let service = handler
+        .serve(transport)
+        .await
+        .map_err(|e| McpError::Connect(e.to_string()))?;
+    let connection = McpConnection {
+        service: Arc::new(service),
+        tools,
+        config,
+    };
+    let _ = connection.refresh_tools().await;
+    Ok(connection)
+}
+
+impl McpConnection {
+    /// Set (or clear with `None`) the per-call timeout applied to tools built by
+    /// subsequent [`tools`](Self::tools) calls. Defaults to
+    /// [`DEFAULT_CALL_TIMEOUT`].
+    pub fn with_call_timeout(self, timeout: impl Into<Option<Duration>>) -> Self {
+        self.config
+            .write()
+            .expect("MCP tool config lock poisoned")
+            .timeout = timeout.into();
+        self
+    }
+
+    /// Set (or clear with `None`) MCP `_meta` attached to subsequent tool,
+    /// prompt, and resource requests.
+    ///
+    /// `_meta` is part of the MCP request envelope, not the model-visible tool
+    /// arguments. Use it for values the server needs but the model should not
+    /// see, such as auth tokens or session ids.
+    pub fn with_call_meta(self, meta: impl Into<Option<Meta>>) -> Self {
+        self.config
+            .write()
+            .expect("MCP tool config lock poisoned")
+            .meta = meta.into();
+        self
+    }
+
+    /// Fetch the server's current tools, update the live tool cache, and adapt
+    /// them into aquaregia [`Tool`]s.
+    ///
+    /// Use [`AgentBuilder::tools`](crate::AgentBuilder::tools) with a
+    /// [`McpConnection`] to register MCP tools as a live tool source. This
+    /// method is for explicit listing or static snapshots.
+    pub async fn list_tools(&self) -> Result<Vec<Tool>, McpError> {
+        self.refresh_tools().await
+    }
+
+    /// Return the currently cached MCP tools without a network round trip.
+    pub async fn current_tools(&self) -> Vec<Tool> {
+        self.tools.read().await.clone()
+    }
+
+    async fn refresh_tools(&self) -> Result<Vec<Tool>, McpError> {
+        self.ensure_connected()?;
+
+        self.service
+            .service()
+            .refresh_tools(self.service.peer().clone())
+            .await
+            .map_err(map_list_tools_error)
+    }
+
+    /// Fetch all prompts currently advertised by the server.
+    pub async fn prompts(&self) -> Result<Vec<Prompt>, McpError> {
+        self.ensure_connected()?;
+
+        let meta = self.config_snapshot().meta;
+        let mut prompts = Vec::new();
+        let mut cursor = None;
+        loop {
+            let result = self
+                .service
+                .peer()
+                .list_prompts(Some(build_paginated_request(cursor, meta.clone())))
+                .await
+                .map_err(map_list_prompts_error)?;
+            prompts.extend(result.prompts);
+            cursor = result.next_cursor;
+            if cursor.is_none() {
+                break;
+            }
+        }
+        Ok(prompts)
+    }
+
+    /// Fetch a prompt by name, optionally passing JSON-object arguments.
+    pub async fn get_prompt(
+        &self,
+        name: impl Into<String>,
+        arguments: impl Into<Option<Value>>,
+    ) -> Result<GetPromptResult, McpError> {
+        self.ensure_connected()?;
+
+        let request =
+            build_get_prompt_request(name, arguments.into(), self.config_snapshot().meta)?;
+        self.service
+            .peer()
+            .get_prompt(request)
+            .await
+            .map_err(map_get_prompt_error)
+    }
+
+    /// Fetch all resources currently advertised by the server.
+    pub async fn resources(&self) -> Result<Vec<Resource>, McpError> {
+        self.ensure_connected()?;
+
+        let meta = self.config_snapshot().meta;
+        let mut resources = Vec::new();
+        let mut cursor = None;
+        loop {
+            let result = self
+                .service
+                .peer()
+                .list_resources(Some(build_paginated_request(cursor, meta.clone())))
+                .await
+                .map_err(map_list_resources_error)?;
+            resources.extend(result.resources);
+            cursor = result.next_cursor;
+            if cursor.is_none() {
+                break;
+            }
+        }
+        Ok(resources)
+    }
+
+    /// Fetch all resource templates currently advertised by the server.
+    pub async fn resource_templates(&self) -> Result<Vec<ResourceTemplate>, McpError> {
+        self.ensure_connected()?;
+
+        let meta = self.config_snapshot().meta;
+        let mut resource_templates = Vec::new();
+        let mut cursor = None;
+        loop {
+            let result = self
+                .service
+                .peer()
+                .list_resource_templates(Some(build_paginated_request(cursor, meta.clone())))
+                .await
+                .map_err(map_list_resource_templates_error)?;
+            resource_templates.extend(result.resource_templates);
+            cursor = result.next_cursor;
+            if cursor.is_none() {
+                break;
+            }
+        }
+        Ok(resource_templates)
+    }
+
+    /// Read the current contents for a resource URI.
+    pub async fn read_resource(
+        &self,
+        uri: impl Into<String>,
+    ) -> Result<ReadResourceResult, McpError> {
+        self.ensure_connected()?;
+
+        let request = build_read_resource_request(uri, self.config_snapshot().meta);
+        self.service
+            .peer()
+            .read_resource(request)
+            .await
+            .map_err(map_read_resource_error)
+    }
+
+    fn ensure_connected(&self) -> Result<(), McpError> {
+        if self.service.peer().is_transport_closed() {
+            return Err(McpError::Disconnected);
+        }
+        Ok(())
+    }
+
+    fn config_snapshot(&self) -> McpToolConfig {
+        self.config
+            .read()
+            .expect("MCP tool config lock poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl ToolSource for McpConnection {
+    async fn tools(&self) -> Result<Vec<Tool>, Error> {
+        Ok(self.current_tools().await)
+    }
+}
+
+fn build_tool_from_mcp(
+    peer: ServerSink,
+    tool: rmcp::model::Tool,
+    config: SharedToolConfig,
+) -> Tool {
+    let descriptor = ToolDescriptor {
+        name: tool.name.to_string(),
+        description: tool.description.as_deref().unwrap_or_default().to_string(),
+        input_schema: serde_json::to_value(&tool.input_schema)
+            .unwrap_or_else(|_| json!({ "type": "object" })),
+    };
+    let executor = Arc::new(McpToolExecutor {
+        peer,
+        tool_name: tool.name.to_string(),
+        config,
+    });
+    Tool::from_parts(descriptor, executor)
+}
+
+struct McpToolExecutor {
+    peer: ServerSink,
+    tool_name: String,
+    config: SharedToolConfig,
+}
+
+#[async_trait]
+impl ToolExecutor for McpToolExecutor {
+    async fn execute(&self, args: Value) -> Result<Value, ToolExecError> {
+        if self.peer.is_transport_closed() {
+            return Err(McpError::Disconnected.into_tool_error());
+        }
+
+        let config = self
+            .config
+            .read()
+            .expect("MCP tool config lock poisoned")
+            .clone();
+        let request = build_call_request(&self.tool_name, args, config.meta)?;
+        let call = self.peer.call_tool(request);
+        let result = match config.timeout {
+            Some(timeout) => tokio::time::timeout(timeout, call)
+                .await
+                .map_err(|_| McpError::CallTimeout.into_tool_error())?
+                .map_err(map_call_error)?,
+            None => call.await.map_err(map_call_error)?,
+        };
+        map_result(result)
+    }
+}
+
+fn build_call_request(
+    tool_name: &str,
+    args: Value,
+    meta: Option<Meta>,
+) -> Result<CallToolRequestParams, ToolExecError> {
+    let mut request = match args {
+        Value::Object(obj) => CallToolRequestParams::new(tool_name.to_string()).with_arguments(obj),
+        Value::Null => CallToolRequestParams::new(tool_name.to_string()),
+        _ => {
+            return Err(ToolExecError::Execution(
+                "MCP tool arguments must be a JSON object".to_string(),
+            ));
+        }
+    };
+    request.meta = meta;
+    Ok(request)
+}
+
+fn build_paginated_request(cursor: Option<String>, meta: Option<Meta>) -> PaginatedRequestParams {
+    let mut request = PaginatedRequestParams::default();
+    request.meta = meta;
+    request.cursor = cursor;
+    request
+}
+
+fn build_get_prompt_request(
+    name: impl Into<String>,
+    arguments: Option<Value>,
+    meta: Option<Meta>,
+) -> Result<GetPromptRequestParams, McpError> {
+    let name = name.into();
+    let mut request = match arguments {
+        Some(Value::Object(arguments)) => {
+            GetPromptRequestParams::new(name).with_arguments(arguments)
+        }
+        Some(Value::Null) | None => GetPromptRequestParams::new(name),
+        _ => {
+            return Err(McpError::InvalidArguments(
+                "MCP prompt arguments must be a JSON object".to_string(),
+            ));
+        }
+    };
+    request.meta = meta;
+    Ok(request)
+}
+
+fn build_read_resource_request(
+    uri: impl Into<String>,
+    meta: Option<Meta>,
+) -> ReadResourceRequestParams {
+    let mut request = ReadResourceRequestParams::new(uri);
+    request.meta = meta;
+    request
+}
+
+fn map_list_tools_error(error: ServiceError) -> McpError {
+    map_service_error(error, McpError::ListTools)
+}
+
+fn map_list_prompts_error(error: ServiceError) -> McpError {
+    map_service_error(error, McpError::ListPrompts)
+}
+
+fn map_get_prompt_error(error: ServiceError) -> McpError {
+    map_service_error(error, McpError::GetPrompt)
+}
+
+fn map_list_resources_error(error: ServiceError) -> McpError {
+    map_service_error(error, McpError::ListResources)
+}
+
+fn map_list_resource_templates_error(error: ServiceError) -> McpError {
+    map_service_error(error, McpError::ListResourceTemplates)
+}
+
+fn map_read_resource_error(error: ServiceError) -> McpError {
+    map_service_error(error, McpError::ReadResource)
+}
+
+fn map_service_error(error: ServiceError, fallback: impl FnOnce(String) -> McpError) -> McpError {
+    match error {
+        ServiceError::TransportClosed => McpError::Disconnected,
+        other => fallback(other.to_string()),
+    }
+}
+
+fn map_call_error(error: ServiceError) -> ToolExecError {
+    match error {
+        ServiceError::TransportClosed => McpError::Disconnected.into_tool_error(),
+        other => ToolExecError::Execution(format!("MCP call failed: {other}")),
+    }
+}
+
+/// Map an MCP tool result into an aquaregia tool result value.
+///
+/// - `is_error: true` becomes a [`ToolExecError::Execution`].
+/// - a single text block collapses to a JSON string (most ergonomic for the model).
+/// - anything else becomes a JSON array of typed content objects.
+fn map_result(result: CallToolResult) -> Result<Value, ToolExecError> {
+    if result.is_error == Some(true) {
+        let text = collect_text(&result.content);
+        return Err(ToolExecError::Execution(if text.is_empty() {
+            "MCP tool returned an error".to_string()
+        } else {
+            text
+        }));
+    }
+
+    if let [ContentBlock::Text(text)] = result.content.as_slice() {
+        return Ok(Value::String(text.text.clone()));
+    }
+
+    let mut parts = Vec::with_capacity(result.content.len());
+    for item in result.content {
+        parts.push(content_to_value(item)?);
+    }
+    Ok(Value::Array(parts))
+}
+
+fn collect_text(content: &[ContentBlock]) -> String {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            ContentBlock::Text(t) => Some(t.text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn content_to_value(raw: ContentBlock) -> Result<Value, ToolExecError> {
+    Ok(match raw {
+        ContentBlock::Text(t) => json!({ "type": "text", "text": t.text }),
+        ContentBlock::Image(img) => json!({
+            "type": "image",
+            "mime_type": img.mime_type,
+            "data": img.data,
+        }),
+        ContentBlock::Resource(res) => match res.resource {
+            ResourceContents::TextResourceContents {
+                uri,
+                mime_type,
+                text,
+                ..
+            } => json!({
+                "type": "resource",
+                "uri": uri,
+                "mime_type": mime_type,
+                "text": text,
+            }),
+            ResourceContents::BlobResourceContents {
+                uri,
+                mime_type,
+                blob,
+                ..
+            } => json!({
+                "type": "resource",
+                "uri": uri,
+                "mime_type": mime_type,
+                "blob": blob,
+            }),
+            _ => {
+                return Err(ToolExecError::Execution(
+                    "unsupported MCP resource content".to_string(),
+                ));
+            }
+        },
+        ContentBlock::ResourceLink(resource) => json!({
+            "type": "resource_link",
+            "uri": resource.uri,
+            "name": resource.name,
+            "title": resource.title,
+            "description": resource.description,
+            "mime_type": resource.mime_type,
+            "size": resource.size,
+        }),
+        ContentBlock::Audio(_) => {
+            return Err(ToolExecError::Execution(
+                "unsupported MCP content: audio".to_string(),
+            ));
+        }
+        _ => {
+            return Err(ToolExecError::Execution(
+                "unsupported MCP content".to_string(),
+            ));
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::model::{CallToolResult, ContentBlock, Resource, ResourceContents};
+    use serde_json::json;
+
+    use super::{
+        Meta, build_call_request, build_get_prompt_request, build_paginated_request,
+        build_read_resource_request, map_result,
+    };
+
+    #[test]
+    fn build_call_request_attaches_meta_outside_arguments() {
+        let mut meta = Meta::new();
+        meta.0
+            .insert("authorization".to_string(), json!("Bearer token"));
+
+        let request = build_call_request("search", json!({ "query": "rust" }), Some(meta.clone()))
+            .expect("request should build");
+
+        assert_eq!(request.meta, Some(meta));
+        assert_eq!(
+            request.arguments.expect("arguments should be set")["query"],
+            "rust"
+        );
+    }
+
+    #[test]
+    fn build_get_prompt_request_attaches_meta_and_arguments() {
+        let mut meta = Meta::new();
+        meta.0.insert("session".to_string(), json!("abc"));
+
+        let request = build_get_prompt_request(
+            "summarize",
+            Some(json!({ "topic": "rust" })),
+            Some(meta.clone()),
+        )
+        .expect("request should build");
+
+        assert_eq!(request.meta, Some(meta));
+        assert_eq!(request.name, "summarize");
+        assert_eq!(
+            request.arguments.expect("arguments should be set")["topic"],
+            "rust"
+        );
+    }
+
+    #[test]
+    fn build_get_prompt_request_rejects_non_object_arguments() {
+        let err = build_get_prompt_request("summarize", Some(json!("rust")), None)
+            .expect_err("string arguments should be rejected");
+
+        assert_eq!(
+            err.to_string(),
+            "MCP prompt arguments must be a JSON object"
+        );
+    }
+
+    #[test]
+    fn build_paginated_request_attaches_meta_and_cursor() {
+        let mut meta = Meta::new();
+        meta.0.insert("session".to_string(), json!("abc"));
+
+        let request = build_paginated_request(Some("next".to_string()), Some(meta.clone()));
+
+        assert_eq!(request.meta, Some(meta));
+        assert_eq!(request.cursor.as_deref(), Some("next"));
+    }
+
+    #[test]
+    fn build_read_resource_request_attaches_meta() {
+        let mut meta = Meta::new();
+        meta.0.insert("session".to_string(), json!("abc"));
+
+        let request = build_read_resource_request("file:///note.txt", Some(meta.clone()));
+
+        assert_eq!(request.meta, Some(meta));
+        assert_eq!(request.uri, "file:///note.txt");
+    }
+
+    #[test]
+    fn maps_single_text_to_json_string() {
+        let value = map_result(CallToolResult::success(vec![ContentBlock::text("ok")]))
+            .expect("text result should map");
+
+        assert_eq!(value, json!("ok"));
+    }
+
+    #[test]
+    fn maps_multiple_blocks_to_typed_array() {
+        let value = map_result(CallToolResult::success(vec![
+            ContentBlock::text("first"),
+            ContentBlock::image("aW1n", "image/png"),
+            ContentBlock::resource(ResourceContents::TextResourceContents {
+                uri: "file:///note.txt".to_string(),
+                mime_type: Some("text/plain".to_string()),
+                text: "note".to_string(),
+                meta: None,
+            }),
+        ]))
+        .expect("mixed result should map");
+
+        assert_eq!(
+            value,
+            json!([
+                { "type": "text", "text": "first" },
+                { "type": "image", "mime_type": "image/png", "data": "aW1n" },
+                {
+                    "type": "resource",
+                    "uri": "file:///note.txt",
+                    "mime_type": "text/plain",
+                    "text": "note",
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn maps_resource_link_to_typed_object() {
+        let value = map_result(CallToolResult::success(vec![ContentBlock::resource_link(
+            Resource::new("file:///note.txt", "note").with_mime_type("text/plain"),
+        )]))
+        .expect("resource link should map");
+
+        assert_eq!(
+            value,
+            json!([
+                {
+                    "type": "resource_link",
+                    "uri": "file:///note.txt",
+                    "name": "note",
+                    "title": null,
+                    "description": null,
+                    "mime_type": "text/plain",
+                    "size": null,
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn maps_mcp_error_result_to_tool_error() {
+        let err = map_result(CallToolResult::error(vec![
+            ContentBlock::text("first failure"),
+            ContentBlock::text("second failure"),
+        ]))
+        .expect_err("MCP error result should fail");
+
+        assert_eq!(
+            err.to_string(),
+            "execution failed: first failure\nsecond failure"
+        );
+    }
+
+    #[test]
+    fn rejects_audio_content() {
+        let err = map_result(CallToolResult::success(vec![ContentBlock::audio(
+            "YXVkaW8=",
+            "audio/wav",
+        )]))
+        .expect_err("audio should be unsupported in the first MCP bridge version");
+
+        assert_eq!(
+            err.to_string(),
+            "execution failed: unsupported MCP content: audio"
+        );
+    }
+}

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -8,7 +8,7 @@
 //! module only maps `rmcp` tools to aquaregia tools and flattens MCP tool
 //! results.
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use aquaregia::providers;
 //! use tokio::process::Command;
 //!

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -2,7 +2,7 @@
 //!
 //! Provider modules are the public entry point for building clients:
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use aquaregia::providers::openai;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,15 +16,63 @@
 //! # }
 //! ```
 
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 use std::sync::Arc;
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 use std::time::Duration;
 
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 use crate::agent::AgentBuilder;
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 use crate::client as core;
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 use crate::embed::{EmbedRequest, EmbedResponse};
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 use crate::error::{Error, ErrorCode};
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 use crate::types::{ChatRequest, ChatResponse, ObjectResponse, ObjectStream, TextStream};
 
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 #[derive(Clone)]
 enum ApiKeySource {
     Missing,
@@ -32,7 +80,14 @@ enum ApiKeySource {
     Env(String),
 }
 
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 impl ApiKeySource {
+    #[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
     fn resolve_required(&self) -> Result<String, Error> {
         match self {
             Self::Missing => Err(Error::new(
@@ -52,6 +107,7 @@ impl ApiKeySource {
         }
     }
 
+    #[cfg(feature = "openai-compatible")]
     fn resolve_optional(&self) -> Result<Option<String>, Error> {
         match self {
             Self::Missing => Ok(None),
@@ -69,6 +125,12 @@ impl ApiKeySource {
     }
 }
 
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 fn validate_api_key(label: &str, value: impl Into<String>) -> Result<String, Error> {
     let value = value.into();
     if value.trim().is_empty() {
@@ -80,6 +142,12 @@ fn validate_api_key(label: &str, value: impl Into<String>) -> Result<String, Err
     Ok(value)
 }
 
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 #[derive(Clone)]
 struct RuntimeConfig {
     timeout: Duration,
@@ -88,6 +156,12 @@ struct RuntimeConfig {
     user_agent: Option<String>,
 }
 
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 impl Default for RuntimeConfig {
     fn default() -> Self {
         Self {
@@ -99,6 +173,12 @@ impl Default for RuntimeConfig {
     }
 }
 
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 macro_rules! runtime_setters {
     () => {
         /// Sets request timeout for all requests sent by this client.
@@ -129,6 +209,12 @@ macro_rules! runtime_setters {
     };
 }
 
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 macro_rules! provider_client_methods {
     () => {
         /// Starts building a model-bound agent.
@@ -171,6 +257,12 @@ macro_rules! provider_client_methods {
     };
 }
 
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
 fn apply_runtime<S: core::BuildProvider>(
     mut builder: core::ClientBuilder<S>,
     runtime: RuntimeConfig,
@@ -186,6 +278,7 @@ fn apply_runtime<S: core::BuildProvider>(
 }
 
 /// OpenAI provider client.
+#[cfg(feature = "openai")]
 pub mod openai {
     use super::*;
 
@@ -258,6 +351,7 @@ pub mod openai {
 }
 
 /// Anthropic provider client.
+#[cfg(feature = "anthropic")]
 pub mod anthropic {
     use super::*;
 
@@ -341,6 +435,7 @@ pub mod anthropic {
 }
 
 /// Google provider client.
+#[cfg(feature = "google")]
 pub mod google {
     use super::*;
 
@@ -413,6 +508,7 @@ pub mod google {
 }
 
 /// OpenAI-compatible provider client.
+#[cfg(feature = "openai-compatible")]
 pub mod openai_compatible {
     use super::*;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,12 +11,20 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use futures_core::Stream;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::error::{Error, ErrorCode};
 use crate::tool::{IntoTool, Tool, ToolDescriptor};
+
+#[async_trait]
+pub(crate) trait ToolSource: Send + Sync {
+    async fn tools(&self) -> Result<Vec<Tool>, Error>;
+}
+
+pub(crate) type ToolSourceRef = Arc<dyn ToolSource>;
 
 /// Chat message role used across providers.
 ///
@@ -600,6 +608,7 @@ pub(crate) struct RunTools {
     pub(crate) model: String,
     pub(crate) messages: Vec<Message>,
     pub(crate) tools: Vec<Tool>,
+    pub(crate) tool_sources: Vec<ToolSourceRef>,
     pub(crate) max_steps: Option<u32>,
     pub(crate) temperature: Option<f32>,
     pub(crate) top_p: Option<f32>,
@@ -624,6 +633,7 @@ impl RunTools {
             model: model.into(),
             messages: Vec::new(),
             tools: Vec::new(),
+            tool_sources: Vec::new(),
             max_steps: None,
             temperature: None,
             top_p: None,
@@ -658,6 +668,12 @@ impl RunTools {
         T: IntoTool,
     {
         self.tools.push(tool.into_tool());
+        self
+    }
+
+    #[cfg(feature = "mcp")]
+    pub(crate) fn tool_source(mut self, source: ToolSourceRef) -> Self {
+        self.tool_sources.push(source);
         self
     }
 

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "openai-compatible")]
+
 use std::sync::{Arc, Mutex};
 
 use aquaregia::types::AgentPreparedStep;

--- a/tests/agent_edge.rs
+++ b/tests/agent_edge.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "openai-compatible")]
+
 use aquaregia::types::AgentPreparedStep;
 use aquaregia::{ErrorCode, Message, ToolErrorPolicy};
 use serde::Deserialize;

--- a/tests/cancellation.rs
+++ b/tests/cancellation.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "openai-compatible")]
+
 use std::sync::Arc;
 
 use aquaregia::tool::{ToolDescriptor, ToolExecError, ToolExecutor};

--- a/tests/client_builder.rs
+++ b/tests/client_builder.rs
@@ -1,3 +1,10 @@
+#![cfg(all(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
+
 use aquaregia::ErrorCode;
 use std::sync::Mutex;
 use std::time::Duration;

--- a/tests/error_mapping.rs
+++ b/tests/error_mapping.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "anthropic")]
+
 use aquaregia::{ChatRequest, ErrorCode, Message};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "openai", feature = "openai-compatible"))]
+
 use aquaregia::tool::ToolDescriptor;
 use aquaregia::types::StreamObjectEvent;
 use aquaregia::{ChatRequest, ErrorCode, Message, OutputSchema};

--- a/tests/multimodal_file.rs
+++ b/tests/multimodal_file.rs
@@ -1,3 +1,9 @@
+#![cfg(all(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "openai-compatible"
+))]
+
 //! Integration tests for FilePart media_type dispatch across adapters.
 
 use aquaregia::{

--- a/tests/provider_options.rs
+++ b/tests/provider_options.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "openai-compatible")]
+
 //! Integration tests for provider_options passthrough.
 
 use aquaregia::{ChatRequest, ContentPart, Message, MessageRole, TextPart, tool};

--- a/tests/providers.rs
+++ b/tests/providers.rs
@@ -1,3 +1,9 @@
+#![cfg(all(
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
+
 use aquaregia::ChatRequest;
 use serde_json::json;
 use wiremock::matchers::{header, method, path};

--- a/tests/providers_deep.rs
+++ b/tests/providers_deep.rs
@@ -1,3 +1,10 @@
+#![cfg(all(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "google",
+    feature = "openai-compatible"
+))]
+
 use aquaregia::tool::ToolDescriptor;
 use aquaregia::{
     ChatRequest, ContentPart, ErrorCode, FinishReason, Message, MessageRole, StreamEvent,

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,3 +1,9 @@
+#![cfg(all(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "openai-compatible"
+))]
+
 use aquaregia::{ChatRequest, FinishReason, Message, StreamEvent};
 use futures_util::StreamExt;
 use wiremock::matchers::{method, path};

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "openai-compatible")]
+
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 


### PR DESCRIPTION
## Summary

- Add an MCP client so agents can call tools from MCP servers.
- Add the remote agent example: an HTTP gateway plus Docker sandbox MCP server, with a built-in web app.
- Split provider features so crates can depend on only the adapters they need.
- Add a `.dockerignore` for the sandbox image and pin the gateway binary in the remote agent README.

## Test plan

- [ ] `cargo test`
- [ ] `cargo check --no-default-features`
- [ ] `cargo check --no-default-features --features openai`
- [ ] `cargo check --no-default-features --features anthropic`
- [ ] Follow `examples/remote_agent/README.md` to start the sandbox MCP server and gateway, then confirm the web app can create a session and run a command.